### PR TITLE
refactor: global install + hub_agents/ lazy init

### DIFF
--- a/terminal_hub/__main__.py
+++ b/terminal_hub/__main__.py
@@ -6,12 +6,16 @@ def main() -> None:
     parser = argparse.ArgumentParser(prog="terminal-hub")
     sub = parser.add_subparsers(dest="command")
     sub.add_parser("install", help="Add terminal-hub to Claude Code for this project")
+    sub.add_parser("verify", help="Check whether terminal-hub is configured for this project")
 
     args = parser.parse_args()
 
     if args.command == "install":
         from terminal_hub.install import run_install
         run_install()
+    elif args.command == "verify":
+        from terminal_hub.install import run_verify
+        run_verify()
     else:
         # Default: start MCP server (no subcommand = MCP stdio mode)
         from terminal_hub.server import create_server

--- a/terminal_hub/config.py
+++ b/terminal_hub/config.py
@@ -11,7 +11,7 @@ class WorkspaceMode(StrEnum):
     GITHUB = "github"
 
 
-_CONFIG_FILE = ".terminal_hub/config.yaml"
+_CONFIG_FILE = "hub_agents/config.yaml"
 
 
 def load_config(root: Path) -> dict[str, Any] | None:

--- a/terminal_hub/env_store.py
+++ b/terminal_hub/env_store.py
@@ -1,10 +1,10 @@
-"""Read/write .terminal_hub/.env for per-project credential and path storage."""
+"""Read/write hub_agents/.env for per-project credential and path storage."""
 from pathlib import Path
 
 
 def read_env(root: Path) -> dict[str, str]:
-    """Parse .terminal_hub/.env. Returns empty dict if file missing."""
-    path = root / ".terminal_hub" / ".env"
+    """Parse hub_agents/.env. Returns empty dict if file missing."""
+    path = root / "hub_agents" / ".env"
     if not path.exists():
         return {}
     result = {}
@@ -19,8 +19,8 @@ def read_env(root: Path) -> dict[str, str]:
 
 
 def write_env(root: Path, values: dict[str, str]) -> None:
-    """Merge values into .terminal_hub/.env and ensure it is gitignored."""
-    path = root / ".terminal_hub" / ".env"
+    """Merge values into hub_agents/.env and ensure hub_agents/ is gitignored."""
+    path = root / "hub_agents" / ".env"
     path.parent.mkdir(parents=True, exist_ok=True)
 
     existing = read_env(root)
@@ -33,8 +33,8 @@ def write_env(root: Path, values: dict[str, str]) -> None:
 
 
 def _ensure_gitignored(root: Path) -> None:
-    """Add .terminal_hub/.env to .gitignore if not already present."""
-    entry = ".terminal_hub/.env"
+    """Add hub_agents/ to .gitignore if not already present."""
+    entry = "hub_agents/"
     gitignore = root / ".gitignore"
     if gitignore.exists():
         content = gitignore.read_text()

--- a/terminal_hub/install.py
+++ b/terminal_hub/install.py
@@ -1,8 +1,8 @@
 """terminal-hub install command.
 
-Writes the MCP server entry into ~/.claude.json for the current project,
-stores PROJECT_ROOT + GITHUB_REPO in .terminal_hub/.env, and ensures
-.terminal_hub/.env is gitignored.
+Writes the MCP server entry into ~/.claude.json at the global level
+(mcpServers, not per-project). All project-specific state is stored in
+hub_agents/ at runtime — no per-project install step needed.
 """
 import json
 import shutil
@@ -10,25 +10,15 @@ import sys
 from pathlib import Path
 
 _CLAUDE_JSON = Path.home() / ".claude.json"
-_SECURITY_NOTICE = """
-\033[33m⚠️  Security notice:\033[0m
-   Credentials are stored in .terminal_hub/.env
-   This file may contain sensitive tokens — do not share it or commit it to git.
-   It has been added to your .gitignore automatically.
-"""
 
 
 # ── Pure functions (testable without I/O) ────────────────────────────────────
 
-def build_mcp_config(root: Path, repo: str | None) -> dict:
-    """Build the MCP server config dict for a project."""
-    env = {"PROJECT_ROOT": str(root)}
-    if repo:
-        env["GITHUB_REPO"] = repo
+def build_mcp_config() -> dict:
+    """Build the global MCP server config dict (no project-specific env vars)."""
     return {
         "command": shutil.which("python3") or "python3",
         "args": ["-m", "terminal_hub"],
-        "env": env,
     }
 
 
@@ -42,94 +32,63 @@ def read_claude_json(path: Path) -> dict:
         return {}
 
 
-def write_claude_json(path: Path, root: Path, config: dict) -> None:
-    """Inject the terminal-hub MCP entry into ~/.claude.json."""
+def write_claude_json(path: Path, config: dict) -> None:
+    """Inject the terminal-hub MCP entry into the global mcpServers section."""
     data = read_claude_json(path)
-    data.setdefault("projects", {})
-    data["projects"].setdefault(str(root), {})
-    data["projects"][str(root)].setdefault("mcpServers", {})
-    data["projects"][str(root)]["mcpServers"]["terminal-hub"] = config
+    data.setdefault("mcpServers", {})
+    data["mcpServers"]["terminal-hub"] = config
     path.write_text(json.dumps(data, indent=2))
 
 
-def format_diff(root: Path, config: dict) -> str:
+def format_diff(config: dict) -> str:
     """Return a human-readable preview of what will be written."""
     lines = [
-        f'Will add to ~/.claude.json:',
-        f'  projects["{root}"]["mcpServers"]["terminal-hub"] = {{',
+        "Will add to ~/.claude.json (global):",
+        '  mcpServers["terminal-hub"] = {',
         f'    "command": "{config["command"]}",',
-        f'    "args": {config["args"]},',
-        f'    "env": {json.dumps(config["env"])}',
-        f'  }}',
+        f'    "args": {config["args"]}',
+        "  }",
     ]
     return "\n".join(lines)
 
 
-# ── Interactive install flow ──────────────────────────────────────────────────
-
-def _prompt(msg: str, default: str = "") -> str:
-    if default:
-        result = input(f"{msg} [{default}]: ").strip()
-        return result or default
-    return input(f"{msg}: ").strip()
-
+# ── Interactive helpers ───────────────────────────────────────────────────────
 
 def _confirm(prompt: str) -> bool:
     return input(f"{prompt} [y/N] ").strip().lower() in ("y", "yes")
 
 
-def _resolve_root() -> Path:
-    from terminal_hub.workspace import resolve_workspace_root, is_valid_project
-    root = resolve_workspace_root()
-    if root and is_valid_project(root):
-        print(f"✓ Detected project directory: {root}")
-        return root
-
-    print("Could not auto-detect project directory.")
-    while True:
-        raw = _prompt("Enter project directory path").strip()
-        path = Path(raw).expanduser().resolve()
-        if path.is_dir():
-            return path
-        print(f"  ✗ Not a directory: {path}")
-
-
-def _resolve_repo(root: Path) -> str | None:
-    from terminal_hub.workspace import detect_repo
-    import os
-    repo = os.environ.get("GITHUB_REPO") or detect_repo(root)
-    if repo:
-        print(f"✓ Detected GitHub repo: {repo}")
-        return repo
-
-    raw = _prompt("Enter GitHub repo (owner/repo) or leave blank for local-only mode", "")
-    return raw.strip() or None
-
+# ── Install ───────────────────────────────────────────────────────────────────
 
 def run_install(claude_json_path: Path = _CLAUDE_JSON) -> None:
-    """Interactive installer. Writes MCP config and .env, then prompts for restart."""
-    print("terminal_hub installer\n")
+    """Install terminal-hub globally into ~/.claude.json."""
+    print("terminal-hub installer\n")
 
-    root = _resolve_root()
-    repo = _resolve_repo(root)
-
-    config = build_mcp_config(root, repo)
-    print()
-    print(format_diff(root, config))
+    config = build_mcp_config()
+    print(format_diff(config))
     print()
 
     if not _confirm("Write this config?"):
         print("Aborted.")
         sys.exit(0)
 
-    write_claude_json(claude_json_path, root, config)
+    write_claude_json(claude_json_path, config)
     print(f"✓ Written to {claude_json_path}")
+    print("\n✓ Restart Claude Code to apply changes.")
+    print("  On first use in any project, terminal-hub will ask you to run setup_workspace.")
 
-    from terminal_hub.env_store import write_env
-    values = {"PROJECT_ROOT": str(root)}
-    if repo:
-        values["GITHUB_REPO"] = repo
-    write_env(root, values)
 
-    print(_SECURITY_NOTICE)
-    print("✓ Restart Claude Code to apply changes.")
+# ── Verify ────────────────────────────────────────────────────────────────────
+
+def run_verify(claude_json_path: Path = _CLAUDE_JSON) -> None:
+    """Check whether terminal-hub is configured globally."""
+    data = read_claude_json(claude_json_path)
+    entry = data.get("mcpServers", {}).get("terminal-hub")
+
+    if entry is None:
+        print("✗ terminal-hub is NOT in global mcpServers.")
+        print("  Run `terminal-hub install` to set it up.")
+        sys.exit(1)
+
+    print("✓ terminal-hub is configured globally.")
+    print(json.dumps(entry, indent=2))

--- a/terminal_hub/server.py
+++ b/terminal_hub/server.py
@@ -6,6 +6,7 @@ from mcp.server.fastmcp import FastMCP
 
 from terminal_hub.auth import TokenSource, get_auth_options, resolve_token, verify_gh_cli_auth
 from terminal_hub.config import WorkspaceMode, load_config, save_config
+from terminal_hub.env_store import read_env, write_env
 from terminal_hub.github_client import GitHubClient, GitHubError
 from terminal_hub.prompts import TERMINAL_HUB_INSTRUCTIONS
 from terminal_hub.slugify import slugify
@@ -21,25 +22,39 @@ from terminal_hub.workspace import detect_repo, init_workspace, resolve_workspac
 
 
 def get_workspace_root() -> Path:
-    """Return resolved workspace root. Falls back to cwd if resolution fails."""
-    return resolve_workspace_root() or Path.cwd()
+    return resolve_workspace_root()
+
+
+def ensure_initialized(root: Path) -> dict | None:
+    """Return a needs_init response if hub_agents/ is absent, else None.
+
+    When returned, Claude should ask the user for their GitHub repo (owner/repo)
+    if they want GitHub integration, then call setup_workspace.
+    """
+    if not (root / "hub_agents").exists():
+        return {
+            "status": "needs_init",
+            "message": (
+                "This project hasn't been set up with terminal-hub yet. "
+                "Ask the user: would they like GitHub integration? If yes, what is their repo (owner/repo format)? "
+                "Then call setup_workspace to initialise."
+            ),
+        }
+    return None
 
 
 def get_github_client() -> tuple[GitHubClient | None, str]:
-    """Return (client, error_message). Client is None if auth unavailable.
-
-    error_message is Claude-readable with a suggestion if client is None.
-    """
+    """Return (client, error_message). Client is None if auth unavailable."""
     token, source = resolve_token()
     if token is None:
         return None, source.suggestion()
 
     root = get_workspace_root()
-    repo = os.environ.get("GITHUB_REPO") or detect_repo(root)
+    repo = detect_repo(root)
     if not repo:
         return None, (
-            "No GitHub repo detected. Set GITHUB_REPO=owner/repo in your MCP config env, "
-            "or run from a directory with a git remote set."
+            "No GitHub repo configured for this project. "
+            "Call setup_workspace with github_repo='owner/repo' to set one."
         )
 
     return GitHubClient(token=token, repo=repo), ""
@@ -47,9 +62,6 @@ def get_github_client() -> tuple[GitHubClient | None, str]:
 
 def create_server() -> FastMCP:
     mcp = FastMCP("terminal-hub")
-
-    # Auto-init workspace on startup
-    init_workspace(get_workspace_root())
 
     @mcp.prompt()
     def terminal_hub_instructions() -> str:
@@ -101,11 +113,13 @@ def create_server() -> FastMCP:
         labels: list[str] | None = None,
         assignees: list[str] | None = None,
     ) -> dict:
-        """Create a GitHub issue and save context locally.
+        """Create a GitHub issue and save context locally in hub_agents/issues/.
         Hint: load terminal_hub_instructions if you haven't yet."""
         root = get_workspace_root()
-        gh, error_msg = get_github_client()
+        if err := ensure_initialized(root):
+            return err
 
+        gh, error_msg = get_github_client()
         if gh is None:
             return {
                 "error": "github_unavailable",
@@ -156,9 +170,11 @@ def create_server() -> FastMCP:
 
     @mcp.tool()
     def list_issues() -> dict:
-        """Return all tracked issues from local .terminal_hub/issues/ files.
+        """Return all tracked issues from local hub_agents/issues/ files.
         Hint: load terminal_hub_instructions if you haven't yet."""
         root = get_workspace_root()
+        if err := ensure_initialized(root):
+            return err
         return {"issues": list_issue_files(root)}
 
     @mcp.tool()
@@ -166,6 +182,8 @@ def create_server() -> FastMCP:
         """Read a specific issue file by slug to reload context cheaply.
         Hint: load terminal_hub_instructions if you haven't yet."""
         root = get_workspace_root()
+        if err := ensure_initialized(root):
+            return err
         content = read_issue_file(root, slug)
         if content is None:
             return {
@@ -178,9 +196,12 @@ def create_server() -> FastMCP:
 
     @mcp.tool()
     def update_project_description(content: str) -> dict:
-        """Overwrite project_description.md. Call get_project_context first to preserve existing content.
+        """Overwrite hub_agents/project_description.md.
+        Call get_project_context first to preserve existing content.
         Hint: load terminal_hub_instructions if you haven't yet."""
         root = get_workspace_root()
+        if err := ensure_initialized(root):
+            return err
         try:
             path = write_doc_file(root, "project_description", content)
             return {"updated": True, "file": str(path.relative_to(root))}
@@ -189,9 +210,12 @@ def create_server() -> FastMCP:
 
     @mcp.tool()
     def update_architecture(content: str) -> dict:
-        """Overwrite architecture_design.md. Call get_project_context first to preserve existing content.
+        """Overwrite hub_agents/architecture_design.md.
+        Call get_project_context first to preserve existing content.
         Hint: load terminal_hub_instructions if you haven't yet."""
         root = get_workspace_root()
+        if err := ensure_initialized(root):
+            return err
         try:
             path = write_doc_file(root, "architecture", content)
             return {"updated": True, "file": str(path.relative_to(root))}
@@ -200,10 +224,12 @@ def create_server() -> FastMCP:
 
     @mcp.tool()
     def get_project_context(file: str) -> dict:
-        """Read project_description.md and/or architecture_design.md.
+        """Read project_description.md and/or architecture_design.md from hub_agents/.
         file: 'project_description', 'architecture', or 'all'.
         Hint: load terminal_hub_instructions if you haven't yet."""
         root = get_workspace_root()
+        if err := ensure_initialized(root):
+            return err
         if file == "all":
             return {
                 "project_description": read_doc_file(root, "project_description"),
@@ -216,48 +242,63 @@ def create_server() -> FastMCP:
 
     @mcp.tool()
     def get_setup_status() -> dict:
-        """Check if this project is configured. Call at session start.
-        If configured=False, present the options to the user and call setup_workspace.
+        """Check if this project has been initialised.
+        If initialised=False, call setup_workspace.
         Hint: load terminal_hub_instructions if you haven't yet."""
         root = get_workspace_root()
-        cfg = load_config(root)
-        if cfg is None:
-            issues_dir = root / ".terminal_hub" / "issues"
-            has_existing = issues_dir.exists() and any(issues_dir.glob("*.md"))
+        hub_dir = root / "hub_agents"
+        if not hub_dir.exists():
             return {
-                "configured": False,
-                "has_existing_data": has_existing,
-                "options": [
-                    {"value": "local", "label": "Local — track plans and issues on this machine only"},
-                    {"value": "github", "label": "GitHub (new repo) — create a new GitHub repository"},
-                    {"value": "connect", "label": "Connect — link to an existing GitHub repository"},
-                ],
+                "initialised": False,
+                "message": (
+                    "hub_agents/ not found. "
+                    "Ask the user if they want GitHub integration and call setup_workspace."
+                ),
             }
-        return {"configured": True, "mode": cfg["mode"], "repo": cfg.get("repo")}
+        cfg = load_config(root)
+        env = read_env(root)
+        return {
+            "initialised": True,
+            "mode": cfg["mode"] if cfg else "unknown",
+            "github_repo": env.get("GITHUB_REPO"),
+        }
 
     @mcp.tool()
     def setup_workspace(
-        mode: str,
-        repo: str | None = None,
+        github_repo: str | None = None,
     ) -> dict:
-        """Configure the workspace for this project.
-        mode: 'local', 'github' (new repo), or 'connect' (existing repo).
-        repo: required for 'github' and 'connect' modes (format: owner/repo-name).
+        """Initialise terminal-hub for this project.
+
+        Creates hub_agents/, stores github_repo in hub_agents/.env if provided,
+        and gitignores hub_agents/.
+
+        github_repo: optional 'owner/repo' — omit for local-only mode.
         Hint: load terminal_hub_instructions if you haven't yet."""
         root = get_workspace_root()
-        valid_modes = {"local", "github", "connect"}
-        if mode not in valid_modes:
-            return {
-                "error": "invalid_mode",
-                "message": f"mode must be one of: {', '.join(sorted(valid_modes))}",
-            }
-        if mode in ("github", "connect") and not repo:
-            return {
-                "error": "missing_repo",
-                "message": f"repo (owner/repo-name) is required for mode '{mode}'",
-            }
-        workspace_mode = WorkspaceMode.LOCAL if mode == "local" else WorkspaceMode.GITHUB
-        save_config(root, workspace_mode, repo)
-        return {"success": True, "mode": mode, "repo": repo}
+
+        init_workspace(root)
+
+        from terminal_hub.env_store import _ensure_gitignored
+        _ensure_gitignored(root)
+
+        values: dict[str, str] = {}
+        if github_repo:
+            values["GITHUB_REPO"] = github_repo
+
+        if values:
+            write_env(root, values)
+
+        mode = WorkspaceMode.GITHUB if github_repo else WorkspaceMode.LOCAL
+        save_config(root, mode, github_repo)
+
+        return {
+            "success": True,
+            "github_repo": github_repo,
+            "hub_dir": str(root / "hub_agents"),
+            "message": (
+                f"Initialised hub_agents/ in {root}. "
+                + (f"GitHub repo set to {github_repo}." if github_repo else "Running in local-only mode.")
+            ),
+        }
 
     return mcp

--- a/terminal_hub/storage.py
+++ b/terminal_hub/storage.py
@@ -6,13 +6,13 @@ from typing import Any
 import yaml
 
 _DOC_FILES = {
-    "project_description": ".terminal_hub/project_description.md",
-    "architecture": ".terminal_hub/architecture_design.md",
+    "project_description": "hub_agents/project_description.md",
+    "architecture": "hub_agents/architecture_design.md",
 }
 
 
 def _issues_dir(root: Path) -> Path:
-    return root / ".terminal_hub" / "issues"
+    return root / "hub_agents" / "issues"
 
 
 def resolve_slug(root: Path, base_slug: str) -> str:
@@ -85,7 +85,7 @@ def list_issue_files(root: Path) -> list[dict[str, Any]]:
                 "created_at": fm.get("created_at"),
                 "assignees": fm.get("assignees", []),
                 "labels": fm.get("labels", []),
-                "file": f".terminal_hub/issues/{slug}.md",
+                "file": f"hub_agents/issues/{slug}.md",
             })
     return sorted(results, key=lambda x: x["created_at"] or "", reverse=True)
 

--- a/terminal_hub/workspace.py
+++ b/terminal_hub/workspace.py
@@ -1,4 +1,4 @@
-"""Auto-initialize .terminal_hub/ directory structure and detect cwd and GitHub repo."""
+"""Workspace root detection and initialisation helpers."""
 import os
 import re
 import subprocess
@@ -12,47 +12,35 @@ def _cwd() -> Path:
 
 def is_valid_project(path: Path) -> bool:
     """True if the directory looks like a project root."""
-    return (path / ".git").exists() or (path / ".terminal_hub").exists()
+    return (path / ".git").exists() or (path / "hub_agents").exists()
 
 
-def resolve_workspace_root() -> Path | None:
-    """Return the workspace root using a prioritised resolution chain.
+def resolve_workspace_root() -> Path:
+    """Return the workspace root.
 
     Order:
-      1. PROJECT_ROOT env var (explicit override)
-      2. PROJECT_ROOT stored in .terminal_hub/.env in cwd
-      3. cwd itself, if it looks like a project
-      4. None — caller must ask the user
+      1. PROJECT_ROOT env var (explicit override / test injection)
+      2. cwd
     """
-    # 1. Explicit env var
     if root := os.environ.get("PROJECT_ROOT"):
         return Path(root)
-
-    cwd = _cwd()
-
-    # 2. .terminal_hub/.env in cwd
-    from terminal_hub.env_store import read_env
-    env = read_env(cwd)
-    if root := env.get("PROJECT_ROOT"):
-        return Path(root)
-
-    # 3. Validate cwd
-    if is_valid_project(cwd):
-        return cwd
-
-    return None
+    return _cwd()
 
 
 def init_workspace(root: Path) -> None:
-    """Create .terminal_hub/ structure if it does not exist. Idempotent."""
-    (root / ".terminal_hub" / "issues").mkdir(parents=True, exist_ok=True)
+    """Create hub_agents/ structure if it does not exist. Idempotent."""
+    (root / "hub_agents" / "issues").mkdir(parents=True, exist_ok=True)
 
 
 def detect_repo(root: Path) -> str | None:
-    """Return 'owner/repo' from GITHUB_REPO env var or git remote origin.
+    """Return 'owner/repo' from hub_agents/.env, GITHUB_REPO env var, or git remote origin.
 
-    Returns None if neither is available.
+    Returns None if none are available.
     """
+    from terminal_hub.env_store import read_env
+    if repo := read_env(root).get("GITHUB_REPO"):
+        return repo
+
     if repo := os.environ.get("GITHUB_REPO"):
         return repo
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,7 +4,7 @@ from terminal_hub.config import load_config, save_config, WorkspaceMode
 
 
 def test_save_and_load_local_config(tmp_path):
-    (tmp_path / ".terminal_hub").mkdir()
+    (tmp_path / "hub_agents").mkdir()
     save_config(tmp_path, mode=WorkspaceMode.LOCAL, repo=None)
     cfg = load_config(tmp_path)
     assert cfg["mode"] == "local"
@@ -12,7 +12,7 @@ def test_save_and_load_local_config(tmp_path):
 
 
 def test_save_and_load_github_config(tmp_path):
-    (tmp_path / ".terminal_hub").mkdir()
+    (tmp_path / "hub_agents").mkdir()
     save_config(tmp_path, mode=WorkspaceMode.GITHUB, repo="owner/my-repo")
     cfg = load_config(tmp_path)
     assert cfg["mode"] == "github"

--- a/tests/test_env_store.py
+++ b/tests/test_env_store.py
@@ -5,7 +5,7 @@ from terminal_hub.env_store import read_env, write_env
 
 @pytest.fixture
 def workspace(tmp_path):
-    (tmp_path / ".terminal_hub").mkdir()
+    (tmp_path / "hub_agents").mkdir()
     return tmp_path
 
 
@@ -41,7 +41,7 @@ def test_write_skips_empty_values(workspace):
 
 
 def test_read_ignores_comments_and_blank_lines(workspace):
-    env_file = workspace / ".terminal_hub" / ".env"
+    env_file = workspace / "hub_agents" / ".env"
     env_file.write_text("# comment\n\nPROJECT_ROOT=/my/project\n")
     result = read_env(workspace)
     assert result == {"PROJECT_ROOT": "/my/project"}
@@ -51,17 +51,17 @@ def test_write_auto_adds_to_gitignore(workspace):
     (workspace / ".gitignore").write_text("*.pyc\n")
     write_env(workspace, {"PROJECT_ROOT": "/x"})
     content = (workspace / ".gitignore").read_text()
-    assert ".terminal_hub/.env" in content
+    assert "hub_agents/" in content
 
 
 def test_write_creates_gitignore_if_missing(workspace):
     write_env(workspace, {"PROJECT_ROOT": "/x"})
     assert (workspace / ".gitignore").exists()
-    assert ".terminal_hub/.env" in (workspace / ".gitignore").read_text()
+    assert "hub_agents/" in (workspace / ".gitignore").read_text()
 
 
 def test_write_does_not_duplicate_gitignore_entry(workspace):
-    (workspace / ".gitignore").write_text(".terminal_hub/.env\n")
+    (workspace / ".gitignore").write_text("hub_agents/\n")
     write_env(workspace, {"PROJECT_ROOT": "/x"})
     content = (workspace / ".gitignore").read_text()
-    assert content.count(".terminal_hub/.env") == 1
+    assert content.count("hub_agents/") == 1

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,4 +1,4 @@
-"""Tests for terminal-hub install command."""
+"""Tests for terminal-hub install command (global install)."""
 import json
 from pathlib import Path
 from unittest.mock import patch
@@ -9,29 +9,22 @@ from terminal_hub.install import build_mcp_config, write_claude_json, read_claud
 @pytest.fixture
 def claude_json(tmp_path):
     path = tmp_path / ".claude.json"
-    path.write_text(json.dumps({"projects": {}}))
+    path.write_text(json.dumps({"mcpServers": {}}))
     return path
-
-
-@pytest.fixture
-def project(tmp_path):
-    (tmp_path / ".git").mkdir()
-    return tmp_path
 
 
 # ── build_mcp_config ──────────────────────────────────────────────────────────
 
-def test_build_config_with_repo(project):
-    cfg = build_mcp_config(project, repo="owner/repo")
+def test_build_config_has_no_env_vars():
+    cfg = build_mcp_config()
+    assert "env" not in cfg
     assert cfg["args"] == ["-m", "terminal_hub"]
-    assert cfg["env"]["PROJECT_ROOT"] == str(project)
-    assert cfg["env"]["GITHUB_REPO"] == "owner/repo"
 
 
-def test_build_config_without_repo(project):
-    cfg = build_mcp_config(project, repo=None)
-    assert "GITHUB_REPO" not in cfg["env"]
-    assert cfg["env"]["PROJECT_ROOT"] == str(project)
+def test_build_config_has_command():
+    cfg = build_mcp_config()
+    assert "command" in cfg
+    assert cfg["command"]  # non-empty
 
 
 # ── read_claude_json ──────────────────────────────────────────────────────────
@@ -55,59 +48,36 @@ def test_read_claude_json_invalid_json_returns_empty(tmp_path):
 
 # ── write_claude_json ─────────────────────────────────────────────────────────
 
-def test_write_adds_mcp_entry(claude_json, project):
-    cfg = build_mcp_config(project, repo="owner/repo")
-    write_claude_json(claude_json, project, cfg)
+def test_write_adds_global_mcp_entry(claude_json):
+    cfg = build_mcp_config()
+    write_claude_json(claude_json, cfg)
 
     data = json.loads(claude_json.read_text())
-    assert "terminal-hub" in data["projects"][str(project)]["mcpServers"]
+    assert "terminal-hub" in data["mcpServers"]
 
 
-def test_write_preserves_existing_projects(claude_json, project, tmp_path):
-    other = tmp_path / "other"
-    existing_data = {
-        "projects": {
-            str(other): {"mcpServers": {"some-other": {}}}
-        }
-    }
-    claude_json.write_text(json.dumps(existing_data))
+def test_write_preserves_existing_mcp_servers(claude_json):
+    existing = {"mcpServers": {"other-tool": {"command": "foo"}}}
+    claude_json.write_text(json.dumps(existing))
 
-    cfg = build_mcp_config(project, repo=None)
-    write_claude_json(claude_json, project, cfg)
+    write_claude_json(claude_json, build_mcp_config())
 
     data = json.loads(claude_json.read_text())
-    assert str(other) in data["projects"]
-    assert str(project) in data["projects"]
+    assert "other-tool" in data["mcpServers"]
+    assert "terminal-hub" in data["mcpServers"]
 
 
-def test_write_preserves_other_mcp_servers(claude_json, project):
-    existing_data = {
-        "projects": {
-            str(project): {"mcpServers": {"other-server": {"command": "foo"}}}
-        }
-    }
-    claude_json.write_text(json.dumps(existing_data))
+def test_write_overwrites_existing_terminal_hub_entry(claude_json):
+    old = {"mcpServers": {"terminal-hub": {"command": "old"}}}
+    claude_json.write_text(json.dumps(old))
 
-    cfg = build_mcp_config(project, repo=None)
-    write_claude_json(claude_json, project, cfg)
+    write_claude_json(claude_json, build_mcp_config())
 
     data = json.loads(claude_json.read_text())
-    servers = data["projects"][str(project)]["mcpServers"]
-    assert "other-server" in servers
-    assert "terminal-hub" in servers
+    assert data["mcpServers"]["terminal-hub"]["command"] != "old"
 
 
-def test_write_overwrites_existing_terminal_hub_entry(claude_json, project):
-    old_data = {
-        "projects": {
-            str(project): {"mcpServers": {"terminal-hub": {"command": "old"}}}
-        }
-    }
-    claude_json.write_text(json.dumps(old_data))
-
-    cfg = build_mcp_config(project, repo="new/repo")
-    write_claude_json(claude_json, project, cfg)
-
+def test_write_does_not_create_projects_key(claude_json):
+    write_claude_json(claude_json, build_mcp_config())
     data = json.loads(claude_json.read_text())
-    entry = data["projects"][str(project)]["mcpServers"]["terminal-hub"]
-    assert entry["env"]["GITHUB_REPO"] == "new/repo"
+    assert "projects" not in data

--- a/tests/test_install_interactive.py
+++ b/tests/test_install_interactive.py
@@ -1,129 +1,67 @@
 """Tests for install.py interactive flow."""
 import json
 from pathlib import Path
-from unittest.mock import patch, call as mock_call
+from unittest.mock import patch
 import pytest
-from terminal_hub.install import run_install, _resolve_root, _resolve_repo, format_diff, build_mcp_config, _prompt
-
-
-@pytest.fixture
-def project(tmp_path):
-    (tmp_path / ".git").mkdir()
-    (tmp_path / ".terminal_hub" / "issues").mkdir(parents=True)
-    return tmp_path
+from terminal_hub.install import run_install, run_verify, build_mcp_config, format_diff
 
 
 @pytest.fixture
 def claude_json(tmp_path):
     path = tmp_path / ".claude.json"
-    path.write_text(json.dumps({"projects": {}}))
+    path.write_text(json.dumps({"mcpServers": {}}))
     return path
-
-
-# ── _prompt ───────────────────────────────────────────────────────────────────
-
-def test_prompt_uses_default_on_empty_input():
-    with patch("builtins.input", return_value=""):
-        assert _prompt("Question", default="fallback") == "fallback"
-
-
-def test_prompt_uses_user_input_over_default():
-    with patch("builtins.input", return_value="typed"):
-        assert _prompt("Question", default="fallback") == "typed"
 
 
 # ── format_diff ───────────────────────────────────────────────────────────────
 
-def test_format_diff_contains_project_root(project):
-    cfg = build_mcp_config(project, "owner/repo")
-    diff = format_diff(project, cfg)
-    assert str(project) in diff
+def test_format_diff_contains_terminal_hub():
+    cfg = build_mcp_config()
+    diff = format_diff(cfg)
     assert "terminal-hub" in diff
-
-
-# ── _resolve_root ─────────────────────────────────────────────────────────────
-
-def test_resolve_root_uses_detected_root(project):
-    with patch("terminal_hub.workspace.resolve_workspace_root", return_value=project):
-        result = _resolve_root()
-    assert result == project
-
-
-def test_resolve_root_prompts_when_detection_fails(project):
-    with patch("terminal_hub.workspace.resolve_workspace_root", return_value=None), \
-         patch("builtins.input", return_value=str(project)):
-        result = _resolve_root()
-    assert result == project
-
-
-def test_resolve_root_retries_on_invalid_path(project):
-    with patch("terminal_hub.workspace.resolve_workspace_root", return_value=None), \
-         patch("builtins.input", side_effect=["/nonexistent/path", str(project)]):
-        result = _resolve_root()
-    assert result == project
-
-
-# ── _resolve_repo ─────────────────────────────────────────────────────────────
-
-def test_resolve_repo_uses_detected_repo(project):
-    with patch("terminal_hub.workspace.detect_repo", return_value="owner/repo"):
-        result = _resolve_repo(project)
-    assert result == "owner/repo"
-
-
-def test_resolve_repo_prompts_when_not_detected(project):
-    with patch("terminal_hub.workspace.detect_repo", return_value=None), \
-         patch("builtins.input", return_value="owner/my-repo"):
-        result = _resolve_repo(project)
-    assert result == "owner/my-repo"
-
-
-def test_resolve_repo_returns_none_on_blank_input(project):
-    with patch("terminal_hub.workspace.detect_repo", return_value=None), \
-         patch("builtins.input", return_value=""):
-        result = _resolve_repo(project)
-    assert result is None
+    assert "global" in diff
 
 
 # ── run_install ───────────────────────────────────────────────────────────────
 
-def test_run_install_writes_claude_json(project, claude_json):
-    with patch("terminal_hub.install._resolve_root", return_value=project), \
-         patch("terminal_hub.install._resolve_repo", return_value="owner/repo"), \
-         patch("builtins.input", return_value="y"):
+def test_run_install_writes_global_mcp_entry(claude_json):
+    with patch("builtins.input", return_value="y"):
         run_install(claude_json_path=claude_json)
 
     data = json.loads(claude_json.read_text())
-    assert "terminal-hub" in data["projects"][str(project)]["mcpServers"]
+    assert "terminal-hub" in data["mcpServers"]
 
 
-def test_run_install_writes_env_file(project, claude_json):
-    with patch("terminal_hub.install._resolve_root", return_value=project), \
-         patch("terminal_hub.install._resolve_repo", return_value="owner/repo"), \
-         patch("builtins.input", return_value="y"):
-        run_install(claude_json_path=claude_json)
-
-    from terminal_hub.env_store import read_env
-    env = read_env(project)
-    assert env["PROJECT_ROOT"] == str(project)
-    assert env["GITHUB_REPO"] == "owner/repo"
-
-
-def test_run_install_aborts_on_no(project, claude_json):
-    with patch("terminal_hub.install._resolve_root", return_value=project), \
-         patch("terminal_hub.install._resolve_repo", return_value=None), \
-         patch("builtins.input", return_value="n"), \
-         pytest.raises(SystemExit):
+def test_run_install_no_env_vars_in_config(claude_json):
+    with patch("builtins.input", return_value="y"):
         run_install(claude_json_path=claude_json)
 
     data = json.loads(claude_json.read_text())
-    assert "terminal-hub" not in data.get("projects", {}).get(str(project), {}).get("mcpServers", {})
+    entry = data["mcpServers"]["terminal-hub"]
+    assert "env" not in entry
 
 
-def test_run_install_gitignores_env(project, claude_json):
-    with patch("terminal_hub.install._resolve_root", return_value=project), \
-         patch("terminal_hub.install._resolve_repo", return_value=None), \
-         patch("builtins.input", return_value="y"):
+def test_run_install_aborts_on_no(claude_json):
+    with patch("builtins.input", return_value="n"), pytest.raises(SystemExit):
         run_install(claude_json_path=claude_json)
 
-    assert ".terminal_hub/.env" in (project / ".gitignore").read_text()
+    data = json.loads(claude_json.read_text())
+    assert "terminal-hub" not in data.get("mcpServers", {})
+
+
+# ── run_verify ────────────────────────────────────────────────────────────────
+
+def test_verify_found(claude_json, capsys):
+    with patch("builtins.input", return_value="y"):
+        run_install(claude_json_path=claude_json)
+
+    run_verify(claude_json_path=claude_json)
+
+    out = capsys.readouterr().out
+    assert "✓" in out
+    assert "terminal-hub" in out
+
+
+def test_verify_not_found_exits(claude_json):
+    with pytest.raises(SystemExit):
+        run_verify(claude_json_path=claude_json)

--- a/tests/test_server_internals.py
+++ b/tests/test_server_internals.py
@@ -29,24 +29,20 @@ def test_get_github_client_no_token_returns_none():
 def test_get_github_client_success():
     from terminal_hub.auth import TokenSource
     with patch("terminal_hub.server.resolve_token", return_value=("tok", TokenSource.ENV)), \
-         patch("terminal_hub.server.detect_repo", return_value="owner/repo"), \
-         patch.dict("os.environ", {"GITHUB_REPO": ""}, clear=False):
-        # Remove GITHUB_REPO so detect_repo fallback runs
-        import os
-        os.environ.pop("GITHUB_REPO", None)
+         patch("terminal_hub.server.detect_repo", return_value="owner/repo"):
         client, msg = get_github_client()
     assert client is not None
     assert msg == ""
     assert client.repo == "owner/repo"
 
 
-def test_get_github_client_env_repo_takes_precedence():
+def test_get_github_client_no_repo_returns_error():
     from terminal_hub.auth import TokenSource
     with patch("terminal_hub.server.resolve_token", return_value=("tok", TokenSource.ENV)), \
-         patch.dict("os.environ", {"GITHUB_REPO": "env/repo"}):
+         patch("terminal_hub.server.detect_repo", return_value=None):
         client, msg = get_github_client()
-    assert client is not None
-    assert client.repo == "env/repo"
+    assert client is None
+    assert "setup_workspace" in msg
 
 
 # ── terminal_hub_instructions prompt ─────────────────────────────────────────
@@ -54,7 +50,6 @@ def test_get_github_client_env_repo_takes_precedence():
 def test_prompt_returns_instructions(tmp_path):
     from terminal_hub.prompts import TERMINAL_HUB_INSTRUCTIONS
     with patch("terminal_hub.server.get_workspace_root", return_value=tmp_path):
-        (tmp_path / ".terminal_hub" / "issues").mkdir(parents=True)
         server = create_server()
 
     prompt_fn = server._prompt_manager.get_prompt("terminal_hub_instructions")
@@ -65,7 +60,7 @@ def test_prompt_returns_instructions(tmp_path):
 # ── create_issue: local write failure after GitHub success ────────────────────
 
 def test_create_issue_local_write_failure_returns_warning(tmp_path):
-    (tmp_path / ".terminal_hub" / "issues").mkdir(parents=True)
+    (tmp_path / "hub_agents" / "issues").mkdir(parents=True)
     mock_gh = MagicMock()
     mock_gh.create_issue.return_value = {"number": 7, "html_url": "http://gh/7"}
 
@@ -81,3 +76,12 @@ def test_create_issue_local_write_failure_returns_warning(tmp_path):
     assert result["local_file"] is None
     assert result["warning"] == "local_write_failed"
     assert "disk full" in result["warning_message"]
+
+
+# ── ensure_initialized guard ──────────────────────────────────────────────────
+
+def test_tools_return_needs_init_when_hub_agents_missing(tmp_path):
+    with patch("terminal_hub.server.get_workspace_root", return_value=tmp_path):
+        server = create_server()
+        result = asyncio.run(server._tool_manager.call_tool("list_issues", {}))
+    assert result["status"] == "needs_init"

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -14,7 +14,7 @@ from terminal_hub.storage import (
 
 @pytest.fixture
 def workspace(tmp_path):
-    (tmp_path / ".terminal_hub" / "issues").mkdir(parents=True)
+    (tmp_path / "hub_agents" / "issues").mkdir(parents=True)
     return tmp_path
 
 
@@ -96,8 +96,7 @@ def test_resolve_slug_no_collision(workspace):
 
 
 def test_resolve_slug_collision_increments(workspace):
-    # Create the base file manually
-    (workspace / ".terminal_hub" / "issues" / "fix-bug.md").write_text("x")
+    (workspace / "hub_agents" / "issues" / "fix-bug.md").write_text("x")
     assert resolve_slug(workspace, "fix-bug") == "fix-bug-2"
 
 
@@ -106,13 +105,13 @@ def test_read_issue_frontmatter_returns_none_when_missing(workspace):
 
 
 def test_read_issue_frontmatter_returns_none_when_no_frontmatter(workspace):
-    path = workspace / ".terminal_hub" / "issues" / "plain.md"
+    path = workspace / "hub_agents" / "issues" / "plain.md"
     path.write_text("# Just a heading\nNo front matter here.")
     assert read_issue_frontmatter(workspace, "plain") is None
 
 
 def test_resolve_slug_multiple_collisions(workspace):
-    issues = workspace / ".terminal_hub" / "issues"
+    issues = workspace / "hub_agents" / "issues"
     (issues / "fix-bug.md").write_text("x")
     (issues / "fix-bug-2.md").write_text("x")
     assert resolve_slug(workspace, "fix-bug") == "fix-bug-3"

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -9,14 +9,14 @@ from terminal_hub.workspace import detect_repo, init_workspace
 
 def test_init_workspace_creates_directories(tmp_path):
     init_workspace(tmp_path)
-    assert (tmp_path / ".terminal_hub").is_dir()
-    assert (tmp_path / ".terminal_hub" / "issues").is_dir()
+    assert (tmp_path / "hub_agents").is_dir()
+    assert (tmp_path / "hub_agents" / "issues").is_dir()
 
 
 def test_init_workspace_is_idempotent(tmp_path):
     init_workspace(tmp_path)
     init_workspace(tmp_path)
-    assert (tmp_path / ".terminal_hub").is_dir()
+    assert (tmp_path / "hub_agents").is_dir()
 
 
 def test_detect_repo_from_env(tmp_path):

--- a/tests/test_workspace_resolution.py
+++ b/tests/test_workspace_resolution.py
@@ -13,7 +13,7 @@ def git_project(tmp_path):
 
 @pytest.fixture
 def hub_project(tmp_path):
-    (tmp_path / ".terminal_hub").mkdir()
+    (tmp_path / "hub_agents").mkdir()
     return tmp_path
 
 
@@ -23,7 +23,7 @@ def test_valid_if_has_git(git_project):
     assert is_valid_project(git_project) is True
 
 
-def test_valid_if_has_terminal_hub(hub_project):
+def test_valid_if_has_hub_agents(hub_project):
     assert is_valid_project(hub_project) is True
 
 
@@ -38,13 +38,11 @@ def test_env_var_takes_priority(git_project):
         assert resolve_workspace_root() == git_project
 
 
-def test_dot_env_file_used_when_no_env_var(tmp_path, git_project):
-    from terminal_hub.env_store import write_env
-    write_env(tmp_path, {"PROJECT_ROOT": str(git_project)})
-    with patch("terminal_hub.workspace._cwd", return_value=tmp_path), \
-         patch.dict(os.environ, {}, clear=True):
+def test_returns_cwd_when_no_env_var(tmp_path):
+    with patch.dict(os.environ, {}, clear=True), \
+         patch("terminal_hub.workspace._cwd", return_value=tmp_path):
         result = resolve_workspace_root()
-    assert result == git_project
+    assert result == tmp_path
 
 
 def test_cwd_used_when_valid(git_project):
@@ -52,10 +50,3 @@ def test_cwd_used_when_valid(git_project):
          patch("terminal_hub.workspace._cwd", return_value=git_project):
         result = resolve_workspace_root()
     assert result == git_project
-
-
-def test_returns_none_when_nothing_found(tmp_path):
-    with patch.dict(os.environ, {}, clear=True), \
-         patch("terminal_hub.workspace._cwd", return_value=tmp_path):
-        result = resolve_workspace_root()
-    assert result is None

--- a/tests/tools/test_auth_tools.py
+++ b/tests/tools/test_auth_tools.py
@@ -10,7 +10,7 @@ def call(server, tool_name, args):
 
 @pytest.fixture
 def workspace(tmp_path):
-    (tmp_path / ".terminal_hub" / "issues").mkdir(parents=True)
+    (tmp_path / "hub_agents" / "issues").mkdir(parents=True)
     return tmp_path
 
 
@@ -64,8 +64,7 @@ def test_create_issue_no_repo_detected(workspace):
     from terminal_hub.auth import TokenSource
     with patch("terminal_hub.server.get_workspace_root", return_value=workspace), \
          patch("terminal_hub.server.resolve_token", return_value=("tok", TokenSource.ENV)), \
-         patch("terminal_hub.server.detect_repo", return_value=None), \
-         patch("os.environ.get", return_value=None):
+         patch("terminal_hub.server.detect_repo", return_value=None):
         server = create_server()
         result = call(server, "create_issue", {"title": "x", "body": "y"})
     assert result["error"] == "github_unavailable"

--- a/tests/tools/test_create_issue.py
+++ b/tests/tools/test_create_issue.py
@@ -11,7 +11,7 @@ def call(server, tool_name, args):
 
 @pytest.fixture
 def workspace(tmp_path):
-    (tmp_path / ".terminal_hub" / "issues").mkdir(parents=True)
+    (tmp_path / "hub_agents" / "issues").mkdir(parents=True)
     return tmp_path
 
 
@@ -27,7 +27,7 @@ def test_create_issue_writes_local_file(workspace):
         server = create_server()
         result = call(server, "create_issue", {"title": "Fix auth bug", "body": "Fix it."})
 
-    assert (workspace / ".terminal_hub" / "issues" / "fix-auth-bug.md").exists()
+    assert (workspace / "hub_agents" / "issues" / "fix-auth-bug.md").exists()
     assert result["issue_number"] == 1
 
 
@@ -55,12 +55,12 @@ def test_create_issue_returns_error_when_no_auth(workspace):
 
 def test_create_issue_collision_resolved(workspace):
     # Pre-create the base slug file to force a -2 slug
-    (workspace / ".terminal_hub" / "issues" / "fix-auth-bug.md").write_text("x")
+    (workspace / "hub_agents" / "issues" / "fix-auth-bug.md").write_text("x")
     with patch("terminal_hub.server.get_github_client", return_value=(_mock_gh(), "")), \
          patch("terminal_hub.server.get_workspace_root", return_value=workspace):
         server = create_server()
         call(server, "create_issue", {"title": "Fix auth bug", "body": "body"})
-    assert (workspace / ".terminal_hub" / "issues" / "fix-auth-bug-2.md").exists()
+    assert (workspace / "hub_agents" / "issues" / "fix-auth-bug-2.md").exists()
 
 
 def test_create_issue_github_error_returns_error(workspace):

--- a/tests/tools/test_get_context.py
+++ b/tests/tools/test_get_context.py
@@ -12,7 +12,7 @@ def call(server, tool_name, args):
 
 @pytest.fixture
 def workspace(tmp_path):
-    (tmp_path / ".terminal_hub" / "issues").mkdir(parents=True)
+    (tmp_path / "hub_agents" / "issues").mkdir(parents=True)
     return tmp_path
 
 

--- a/tests/tools/test_list_issues.py
+++ b/tests/tools/test_list_issues.py
@@ -12,7 +12,7 @@ def call(server, tool_name, args):
 
 @pytest.fixture
 def workspace(tmp_path):
-    (tmp_path / ".terminal_hub" / "issues").mkdir(parents=True)
+    (tmp_path / "hub_agents" / "issues").mkdir(parents=True)
     return tmp_path
 
 

--- a/tests/tools/test_setup_status_existing.py
+++ b/tests/tools/test_setup_status_existing.py
@@ -1,4 +1,4 @@
-"""Tests for get_setup_status detecting existing .terminal_hub/ data."""
+"""Tests for get_setup_status with existing hub_agents/ data."""
 import asyncio
 from unittest.mock import patch
 import pytest
@@ -9,38 +9,30 @@ def call(server, tool_name, args):
     return asyncio.run(server._tool_manager.call_tool(tool_name, args))
 
 
-def test_has_existing_data_when_issues_present(tmp_path):
-    """Returning workspace: .terminal_hub/issues/ exists but no config.yaml."""
-    (tmp_path / ".terminal_hub" / "issues").mkdir(parents=True)
-    (tmp_path / ".terminal_hub" / "issues" / "old-issue.md").write_text("---\ntitle: old\n---\n")
-
+def test_not_initialised_when_hub_agents_missing(tmp_path):
     with patch("terminal_hub.server.get_workspace_root", return_value=tmp_path):
         server = create_server()
         result = call(server, "get_setup_status", {})
-
-    assert result["configured"] is False
-    assert result["has_existing_data"] is True
+    assert result["initialised"] is False
 
 
-def test_no_existing_data_on_fresh_workspace(tmp_path):
-    (tmp_path / ".terminal_hub" / "issues").mkdir(parents=True)
-
-    with patch("terminal_hub.server.get_workspace_root", return_value=tmp_path):
-        server = create_server()
-        result = call(server, "get_setup_status", {})
-
-    assert result["configured"] is False
-    assert result["has_existing_data"] is False
-
-
-def test_configured_does_not_include_has_existing_data(tmp_path):
+def test_initialised_when_hub_agents_exists(tmp_path):
+    (tmp_path / "hub_agents" / "issues").mkdir(parents=True)
     from terminal_hub.config import WorkspaceMode, save_config
-    (tmp_path / ".terminal_hub" / "issues").mkdir(parents=True)
     save_config(tmp_path, WorkspaceMode.LOCAL, None)
-
     with patch("terminal_hub.server.get_workspace_root", return_value=tmp_path):
         server = create_server()
         result = call(server, "get_setup_status", {})
+    assert result["initialised"] is True
 
-    assert result["configured"] is True
-    assert "has_existing_data" not in result
+
+def test_github_repo_returned_when_configured(tmp_path):
+    (tmp_path / "hub_agents" / "issues").mkdir(parents=True)
+    from terminal_hub.config import WorkspaceMode, save_config
+    from terminal_hub.env_store import write_env
+    save_config(tmp_path, WorkspaceMode.GITHUB, "owner/repo")
+    write_env(tmp_path, {"GITHUB_REPO": "owner/repo"})
+    with patch("terminal_hub.server.get_workspace_root", return_value=tmp_path):
+        server = create_server()
+        result = call(server, "get_setup_status", {})
+    assert result["github_repo"] == "owner/repo"

--- a/tests/tools/test_setup_workspace.py
+++ b/tests/tools/test_setup_workspace.py
@@ -10,63 +10,55 @@ def call(server, tool_name, args):
 
 @pytest.fixture
 def workspace(tmp_path):
-    (tmp_path / ".terminal_hub" / "issues").mkdir(parents=True)
+    (tmp_path / "hub_agents" / "issues").mkdir(parents=True)
     return tmp_path
 
 
-def test_get_setup_status_not_configured(workspace):
-    with patch("terminal_hub.server.get_workspace_root", return_value=workspace):
+def test_get_setup_status_not_initialised(tmp_path):
+    with patch("terminal_hub.server.get_workspace_root", return_value=tmp_path):
         server = create_server()
         result = call(server, "get_setup_status", {})
-    assert result["configured"] is False
-    assert "options" in result
-    assert len(result["options"]) == 3
+    assert result["initialised"] is False
+    assert "message" in result
 
 
-def test_get_setup_status_configured(workspace):
+def test_get_setup_status_initialised(workspace):
     from terminal_hub.config import WorkspaceMode, save_config
     save_config(workspace, WorkspaceMode.LOCAL, None)
     with patch("terminal_hub.server.get_workspace_root", return_value=workspace):
         server = create_server()
         result = call(server, "get_setup_status", {})
-    assert result["configured"] is True
+    assert result["initialised"] is True
     assert result["mode"] == "local"
 
 
-def test_setup_local_mode(workspace):
-    with patch("terminal_hub.server.get_workspace_root", return_value=workspace):
+def test_setup_local_mode(tmp_path):
+    with patch("terminal_hub.server.get_workspace_root", return_value=tmp_path):
         server = create_server()
-        result = call(server, "setup_workspace", {"mode": "local"})
+        result = call(server, "setup_workspace", {})
     assert result["success"] is True
-    assert result["mode"] == "local"
-    assert (workspace / ".terminal_hub" / "config.yaml").exists()
+    assert (tmp_path / "hub_agents" / "config.yaml").exists()
 
 
-def test_setup_github_mode(workspace):
-    with patch("terminal_hub.server.get_workspace_root", return_value=workspace):
+def test_setup_with_github_repo(tmp_path):
+    with patch("terminal_hub.server.get_workspace_root", return_value=tmp_path):
         server = create_server()
-        result = call(server, "setup_workspace", {"mode": "github", "repo": "owner/my-repo"})
+        result = call(server, "setup_workspace", {"github_repo": "owner/my-repo"})
     assert result["success"] is True
-    assert result["repo"] == "owner/my-repo"
+    assert result["github_repo"] == "owner/my-repo"
+    from terminal_hub.env_store import read_env
+    assert read_env(tmp_path)["GITHUB_REPO"] == "owner/my-repo"
 
 
-def test_setup_connect_mode(workspace):
-    with patch("terminal_hub.server.get_workspace_root", return_value=workspace):
+def test_setup_creates_hub_agents_dir(tmp_path):
+    with patch("terminal_hub.server.get_workspace_root", return_value=tmp_path):
         server = create_server()
-        result = call(server, "setup_workspace", {"mode": "connect", "repo": "owner/existing"})
-    assert result["success"] is True
-    assert result["mode"] == "connect"
+        call(server, "setup_workspace", {})
+    assert (tmp_path / "hub_agents").exists()
 
 
-def test_setup_rejects_invalid_mode(workspace):
-    with patch("terminal_hub.server.get_workspace_root", return_value=workspace):
+def test_setup_gitignores_hub_agents(tmp_path):
+    with patch("terminal_hub.server.get_workspace_root", return_value=tmp_path):
         server = create_server()
-        result = call(server, "setup_workspace", {"mode": "invalid"})
-    assert result["error"] == "invalid_mode"
-
-
-def test_setup_github_requires_repo(workspace):
-    with patch("terminal_hub.server.get_workspace_root", return_value=workspace):
-        server = create_server()
-        result = call(server, "setup_workspace", {"mode": "github"})
-    assert result["error"] == "missing_repo"
+        call(server, "setup_workspace", {})
+    assert "hub_agents/" in (tmp_path / ".gitignore").read_text()

--- a/tests/tools/test_update_docs.py
+++ b/tests/tools/test_update_docs.py
@@ -10,7 +10,7 @@ def call(server, tool_name, args):
 
 @pytest.fixture
 def workspace(tmp_path):
-    (tmp_path / ".terminal_hub" / "issues").mkdir(parents=True)
+    (tmp_path / "hub_agents" / "issues").mkdir(parents=True)
     return tmp_path
 
 
@@ -19,14 +19,14 @@ def test_update_project_description_writes_file(workspace):
         server = create_server()
         result = call(server, "update_project_description", {"content": "# My Project\n"})
     assert result["updated"] is True
-    assert (workspace / ".terminal_hub" / "project_description.md").read_text() == "# My Project\n"
+    assert (workspace / "hub_agents" / "project_description.md").read_text() == "# My Project\n"
 
 
 def test_update_project_description_returns_relative_path(workspace):
     with patch("terminal_hub.server.get_workspace_root", return_value=workspace):
         server = create_server()
         result = call(server, "update_project_description", {"content": "text"})
-    assert ".terminal_hub/project_description.md" in result["file"]
+    assert "hub_agents/project_description.md" in result["file"]
 
 
 def test_update_architecture_writes_file(workspace):
@@ -34,7 +34,7 @@ def test_update_architecture_writes_file(workspace):
         server = create_server()
         result = call(server, "update_architecture", {"content": "# Architecture\n"})
     assert result["updated"] is True
-    assert (workspace / ".terminal_hub" / "architecture_design.md").read_text() == "# Architecture\n"
+    assert (workspace / "hub_agents" / "architecture_design.md").read_text() == "# Architecture\n"
 
 
 def test_update_docs_overwrite_preserves_latest(workspace):
@@ -42,4 +42,4 @@ def test_update_docs_overwrite_preserves_latest(workspace):
         server = create_server()
         call(server, "update_project_description", {"content": "v1"})
         call(server, "update_project_description", {"content": "v2"})
-    assert (workspace / ".terminal_hub" / "project_description.md").read_text() == "v2"
+    assert (workspace / "hub_agents" / "project_description.md").read_text() == "v2"


### PR DESCRIPTION
## Summary
- Install is now global (one `terminal-hub install`, available in every project)
- `.terminal_hub/` replaced by `hub_agents/` — entire dir gitignored by default
- Lazy init via MCP: tools return `{status: needs_init}` when `hub_agents/` is absent, Claude asks user for GitHub repo and calls `setup_workspace`
- `setup_workspace` is now the single init entry point — creates dir, writes `.env`, gitignores
- `resolve_workspace_root` simplified (no per-project env chain needed)

## Test plan
- [ ] `terminal-hub install` writes to global `mcpServers` with no env vars
- [ ] `terminal-hub verify` checks global entry
- [ ] Calling any tool in an uninitialised project returns `needs_init`
- [ ] `setup_workspace(github_repo="owner/repo")` creates `hub_agents/`, writes `.env`, gitignores dir
- [ ] `hub_agents/` is gitignored, not `.terminal_hub/`
- [ ] 130 tests, 98% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)