### PR TITLE
feat: guided prompt hook — persistent workflow instructions (#11)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "terminal-hub:.*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo '[terminal-hub] Refer to terminal-hub://instructions for workflow guidance.'"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/agents/entry_point.md
+++ b/agents/entry_point.md
@@ -1,0 +1,71 @@
+# terminal-hub Entry Point Agent
+
+You are the entry point agent for terminal-hub, an MCP server that helps users manage GitHub issues and project context directly from Claude Code conversations.
+
+## What you do
+
+When a user starts a new session or asks you to help with project planning, issue tracking, or workspace setup, you orchestrate the terminal-hub MCP tools to assist them.
+
+---
+
+## Code structure awareness
+
+The server exposes tools via `terminal_hub/server.py` (FastMCP). All state lives in `hub_agents/` inside the project directory — this dir is gitignored and created on first use.
+
+**Key files:**
+- `terminal_hub/server.py` — all MCP tools (check_auth, setup_workspace, create_issue, list_issues, get_issue_context, update_project_description, update_architecture, get_project_context, get_setup_status)
+- `terminal_hub/workspace.py` — `resolve_workspace_root()` → returns `PROJECT_ROOT` env var or cwd
+- `terminal_hub/env_store.py` — reads/writes `hub_agents/.env` (GITHUB_REPO, optional GITHUB_TOKEN)
+- `terminal_hub/storage.py` — issue files at `hub_agents/issues/<slug>.md` with YAML front matter; doc files at `hub_agents/project_description.md` and `hub_agents/architecture_design.md`
+- `terminal_hub/auth.py` — token resolution: `GITHUB_TOKEN` env → `gh auth token` CLI → none
+- `terminal_hub/config.py` — `hub_agents/config.yaml` stores workspace mode (local / github)
+- `terminal_hub/install.py` — `terminal-hub install` writes to global `~/.claude.json mcpServers`
+
+**Hub agents directory layout (per project):**
+```
+hub_agents/
+├── .env                   # GITHUB_REPO, optional GITHUB_TOKEN
+├── config.yaml            # mode: local|github, repo: owner/repo
+├── issues/
+│   └── <slug>.md          # YAML front matter + body
+├── project_description.md
+└── architecture_design.md
+```
+
+---
+
+## Session start flow
+
+1. Call `get_setup_status`
+   - If `initialised: false` → see `terminal-hub://workflow/init`
+   - If `initialised: true` → see `terminal-hub://workflow/context` to reload saved context, then assist
+
+2. If the user mentions GitHub and auth fails → see `terminal-hub://workflow/auth`
+
+---
+
+## Tool quick reference
+
+| Tool | When to use |
+|------|-------------|
+| `get_setup_status` | Always call first |
+| `setup_workspace` | When `initialised: false` |
+| `check_auth` | Auth error on any GitHub tool |
+| `verify_auth` | After user runs `gh auth login` |
+| `create_issue` | User wants to log a task or bug on GitHub |
+| `list_issues` | User asks what's tracked / what to work on next |
+| `get_issue_context` | Reload context for a specific issue by slug |
+| `update_project_description` | User describes the project; save it for future sessions |
+| `update_architecture` | User explains tech stack or design decisions |
+| `get_project_context` | Before writing code — reload saved project context |
+
+---
+
+## Rules
+
+- Always call `get_setup_status` before any other tool in a new session
+- Never ask for `GITHUB_TOKEN` directly — direct the user to `gh auth login` or setting the env var
+- Issue slugs are auto-generated from titles (e.g. "Fix auth bug" → `fix-auth-bug`); use `list_issues` to find the right slug
+- `get_project_context(file="all")` is cheap — call it at session start to reload saved context
+- If a tool returns `{status: "needs_init"}` → follow `_guidance` URI or call `setup_workspace`
+- If a tool returns `{error: "github_unavailable"}` → follow `_guidance` URI or call `check_auth`

--- a/agents/workflow_auth.md
+++ b/agents/workflow_auth.md
@@ -1,0 +1,26 @@
+# Workflow: Auth recovery
+
+**Trigger:** Any GitHub tool returns `{error: "github_unavailable"}` or `{authenticated: false}`
+
+## Steps
+
+1. Call `check_auth()`
+
+2. If `authenticated: true` — auth is fine, the original error was likely a repo config issue.
+   Ask the user to confirm their repo with `setup_workspace(github_repo="owner/repo")`.
+
+3. If `authenticated: false`, present the options from the response:
+   > "GitHub authentication isn't set up. You can:"
+   > "  a) Run `gh auth login` in your terminal (recommended)"
+   > "  b) Set `GITHUB_TOKEN=<token>` in your environment"
+
+4. After the user reports they've run `gh auth login`:
+   - Call `verify_auth()`
+   - If `authenticated: true`: > "Authenticated. Retrying your original request..."
+     Then retry the tool call that originally failed.
+   - If still false: repeat step 3.
+
+## Rules
+
+- Never ask the user to paste a token into the chat
+- After successful `verify_auth`, always retry the originally-failed tool automatically

--- a/agents/workflow_context.md
+++ b/agents/workflow_context.md
@@ -1,0 +1,30 @@
+# Workflow: Project context
+
+**Trigger:** Session start (after init), or user describes the project / architecture.
+
+## Load context at session start
+
+1. Call `get_project_context(file="all")`
+2. If both fields are non-null, summarise briefly for the user:
+   > "Loaded saved context: {project_description summary} / {architecture summary}"
+3. If null, offer to capture it:
+   > "No project context saved yet. Want me to record a description or architecture notes?"
+
+## Save project description
+
+1. Call `get_project_context(file="project_description")` first to avoid overwriting
+2. Merge user input with any existing content
+3. Call `update_project_description(content=...)`
+4. Confirm: > "Saved to hub_agents/project_description.md"
+
+## Save architecture notes
+
+1. Call `get_project_context(file="architecture")` first
+2. Merge user input with existing
+3. Call `update_architecture(content=...)`
+4. Confirm: > "Saved to hub_agents/architecture_design.md"
+
+## Rules
+
+- Always read before writing — never blindly overwrite existing content
+- Keep descriptions in markdown; include headings for easy future scanning

--- a/agents/workflow_init.md
+++ b/agents/workflow_init.md
@@ -1,0 +1,27 @@
+# Workflow: Initialise workspace
+
+**Trigger:** `get_setup_status` returns `{initialised: false}`
+
+## Steps
+
+1. Ask the user:
+   > "This project hasn't been set up with terminal-hub yet. Would you like GitHub integration?
+   > If yes, what is your repository? (format: `owner/repo`)"
+
+2. Based on the answer:
+   - **GitHub integration** → call `setup_workspace(github_repo="owner/repo")`
+   - **Local only** → call `setup_workspace()` (no argument)
+
+3. Confirm success:
+   > "Done! terminal-hub is ready. hub_agents/ has been created and gitignored."
+
+4. If `github_repo` was set and auth is uncertain → call `check_auth` immediately.
+   If not authenticated → follow `terminal-hub://workflow/auth`.
+
+5. Proceed to `terminal-hub://workflow/context` to reload any saved project context.
+
+## Error cases
+
+| Response | Action |
+|----------|--------|
+| `setup_workspace` fails with any error | Report the error message verbatim, ask the user to check directory permissions |

--- a/agents/workflow_issue.md
+++ b/agents/workflow_issue.md
@@ -1,0 +1,36 @@
+# Workflow: Create and track issues
+
+**Trigger:** User mentions a task, bug, feature request, or asks what to work on next.
+
+## Create an issue
+
+1. Gather from the user (ask only what's missing):
+   - **title** — short, imperative (e.g. "Fix login redirect")
+   - **body** — context, reproduction steps, or acceptance criteria
+   - **labels** — optional (e.g. `["bug", "priority-high"]`)
+   - **assignees** — optional GitHub usernames
+
+2. Call `create_issue(title=..., body=..., labels=..., assignees=...)`
+
+3. On success, confirm:
+   > "Created issue #`{issue_number}`: `{url}`
+   > Saved locally at `{local_file}`."
+
+4. On `{error: "github_unavailable"}` → follow `terminal-hub://workflow/auth`.
+
+## List issues
+
+1. Call `list_issues()`
+2. Present as a numbered list: `#{issue_number} — {title} ({slug})`
+3. Offer: "Would you like context on any of these?"
+
+## Reload issue context
+
+1. Use the slug from `list_issues` output
+2. Call `get_issue_context(slug="...")`
+3. Summarise the issue body and front matter for the user
+
+## Rules
+
+- Never guess a slug — always get it from `list_issues` first
+- If `local_file` is null in the create response, warn the user the local write failed but the GitHub issue was created successfully

--- a/terminal_hub/server.py
+++ b/terminal_hub/server.py
@@ -8,7 +8,6 @@ from terminal_hub.auth import TokenSource, get_auth_options, resolve_token, veri
 from terminal_hub.config import WorkspaceMode, load_config, save_config
 from terminal_hub.env_store import read_env, write_env
 from terminal_hub.github_client import GitHubClient, GitHubError
-from terminal_hub.prompts import TERMINAL_HUB_INSTRUCTIONS
 from terminal_hub.slugify import slugify
 from terminal_hub.storage import (
     list_issue_files,
@@ -20,17 +19,26 @@ from terminal_hub.storage import (
 )
 from terminal_hub.workspace import detect_repo, init_workspace, resolve_workspace_root
 
+_AGENTS_DIR = Path(__file__).parent.parent / "agents"
+
+# ── Guidance URIs ─────────────────────────────────────────────────────────────
+_G_INIT   = "terminal-hub://workflow/init"
+_G_ISSUE  = "terminal-hub://workflow/issue"
+_G_CONTEXT = "terminal-hub://workflow/context"
+_G_AUTH   = "terminal-hub://workflow/auth"
+
+
+def _load_agent(name: str) -> str:
+    path = _AGENTS_DIR / name
+    return path.read_text() if path.exists() else ""
+
 
 def get_workspace_root() -> Path:
     return resolve_workspace_root()
 
 
 def ensure_initialized(root: Path) -> dict | None:
-    """Return a needs_init response if hub_agents/ is absent, else None.
-
-    When returned, Claude should ask the user for their GitHub repo (owner/repo)
-    if they want GitHub integration, then call setup_workspace.
-    """
+    """Return a needs_init response if hub_agents/ is absent, else None."""
     if not (root / "hub_agents").exists():
         return {
             "status": "needs_init",
@@ -39,6 +47,7 @@ def ensure_initialized(root: Path) -> dict | None:
                 "Ask the user: would they like GitHub integration? If yes, what is their repo (owner/repo format)? "
                 "Then call setup_workspace to initialise."
             ),
+            "_guidance": _G_INIT,
         }
     return None
 
@@ -61,11 +70,34 @@ def get_github_client() -> tuple[GitHubClient | None, str]:
 
 
 def create_server() -> FastMCP:
-    mcp = FastMCP("terminal-hub")
+    mcp = FastMCP("terminal-hub", instructions=_load_agent("entry_point.md"))
 
-    @mcp.prompt()
-    def terminal_hub_instructions() -> str:
-        return TERMINAL_HUB_INSTRUCTIONS
+    # ── Resources (workflow guides) ───────────────────────────────────────────
+
+    @mcp.resource("terminal-hub://instructions")
+    def instructions_resource() -> str:
+        """Full entry point instructions and tool reference."""
+        return _load_agent("entry_point.md")
+
+    @mcp.resource("terminal-hub://workflow/init")
+    def workflow_init() -> str:
+        """Step-by-step guide for initialising a new project workspace."""
+        return _load_agent("workflow_init.md")
+
+    @mcp.resource("terminal-hub://workflow/issue")
+    def workflow_issue() -> str:
+        """Guide for creating, listing, and reloading issue context."""
+        return _load_agent("workflow_issue.md")
+
+    @mcp.resource("terminal-hub://workflow/context")
+    def workflow_context() -> str:
+        """Guide for loading and saving project description and architecture."""
+        return _load_agent("workflow_context.md")
+
+    @mcp.resource("terminal-hub://workflow/auth")
+    def workflow_auth() -> str:
+        """Auth recovery guide — check_auth → gh auth login → verify_auth."""
+        return _load_agent("workflow_auth.md")
 
     # ── Auth tools ────────────────────────────────────────────────────────────
 
@@ -85,6 +117,7 @@ def create_server() -> FastMCP:
             "authenticated": False,
             "message": "No GitHub authentication found.",
             "options": get_auth_options(),
+            "_guidance": _G_AUTH,
         }
 
     @mcp.tool()
@@ -102,6 +135,7 @@ def create_server() -> FastMCP:
             "authenticated": False,
             "message": message,
             "options": get_auth_options(),
+            "_guidance": _G_AUTH,
         }
 
     # ── Issue tools ───────────────────────────────────────────────────────────
@@ -113,8 +147,7 @@ def create_server() -> FastMCP:
         labels: list[str] | None = None,
         assignees: list[str] | None = None,
     ) -> dict:
-        """Create a GitHub issue and save context locally in hub_agents/issues/.
-        Hint: load terminal_hub_instructions if you haven't yet."""
+        """Create a GitHub issue and save context locally in hub_agents/issues/."""
         root = get_workspace_root()
         if err := ensure_initialized(root):
             return err
@@ -125,6 +158,7 @@ def create_server() -> FastMCP:
                 "error": "github_unavailable",
                 "message": error_msg,
                 "suggestion": "Call check_auth to present login options to the user.",
+                "_guidance": _G_AUTH,
             }
 
         try:
@@ -170,8 +204,7 @@ def create_server() -> FastMCP:
 
     @mcp.tool()
     def list_issues() -> dict:
-        """Return all tracked issues from local hub_agents/issues/ files.
-        Hint: load terminal_hub_instructions if you haven't yet."""
+        """Return all tracked issues from local hub_agents/issues/ files."""
         root = get_workspace_root()
         if err := ensure_initialized(root):
             return err
@@ -179,8 +212,7 @@ def create_server() -> FastMCP:
 
     @mcp.tool()
     def get_issue_context(slug: str) -> dict:
-        """Read a specific issue file by slug to reload context cheaply.
-        Hint: load terminal_hub_instructions if you haven't yet."""
+        """Read a specific issue file by slug to reload context cheaply."""
         root = get_workspace_root()
         if err := ensure_initialized(root):
             return err
@@ -197,8 +229,7 @@ def create_server() -> FastMCP:
     @mcp.tool()
     def update_project_description(content: str) -> dict:
         """Overwrite hub_agents/project_description.md.
-        Call get_project_context first to preserve existing content.
-        Hint: load terminal_hub_instructions if you haven't yet."""
+        Call get_project_context first to preserve existing content."""
         root = get_workspace_root()
         if err := ensure_initialized(root):
             return err
@@ -211,8 +242,7 @@ def create_server() -> FastMCP:
     @mcp.tool()
     def update_architecture(content: str) -> dict:
         """Overwrite hub_agents/architecture_design.md.
-        Call get_project_context first to preserve existing content.
-        Hint: load terminal_hub_instructions if you haven't yet."""
+        Call get_project_context first to preserve existing content."""
         root = get_workspace_root()
         if err := ensure_initialized(root):
             return err
@@ -225,8 +255,7 @@ def create_server() -> FastMCP:
     @mcp.tool()
     def get_project_context(file: str) -> dict:
         """Read project_description.md and/or architecture_design.md from hub_agents/.
-        file: 'project_description', 'architecture', or 'all'.
-        Hint: load terminal_hub_instructions if you haven't yet."""
+        file: 'project_description', 'architecture', or 'all'."""
         root = get_workspace_root()
         if err := ensure_initialized(root):
             return err
@@ -242,9 +271,7 @@ def create_server() -> FastMCP:
 
     @mcp.tool()
     def get_setup_status() -> dict:
-        """Check if this project has been initialised.
-        If initialised=False, call setup_workspace.
-        Hint: load terminal_hub_instructions if you haven't yet."""
+        """Check if this project has been initialised. Always call this first."""
         root = get_workspace_root()
         hub_dir = root / "hub_agents"
         if not hub_dir.exists():
@@ -254,6 +281,7 @@ def create_server() -> FastMCP:
                     "hub_agents/ not found. "
                     "Ask the user if they want GitHub integration and call setup_workspace."
                 ),
+                "_guidance": _G_INIT,
             }
         cfg = load_config(root)
         env = read_env(root)
@@ -264,16 +292,13 @@ def create_server() -> FastMCP:
         }
 
     @mcp.tool()
-    def setup_workspace(
-        github_repo: str | None = None,
-    ) -> dict:
+    def setup_workspace(github_repo: str | None = None) -> dict:
         """Initialise terminal-hub for this project.
 
         Creates hub_agents/, stores github_repo in hub_agents/.env if provided,
         and gitignores hub_agents/.
 
-        github_repo: optional 'owner/repo' — omit for local-only mode.
-        Hint: load terminal_hub_instructions if you haven't yet."""
+        github_repo: optional 'owner/repo' — omit for local-only mode."""
         root = get_workspace_root()
 
         init_workspace(root)

--- a/tests/test_instructions_hook.py
+++ b/tests/test_instructions_hook.py
@@ -1,0 +1,182 @@
+"""Tests for guided prompt hook: resources, _guidance fields, workflow files."""
+import asyncio
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from terminal_hub.server import _AGENTS_DIR, _load_agent, create_server
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def call(server, tool_name, args):
+    return asyncio.run(server._tool_manager.call_tool(tool_name, args))
+
+
+def read_resource(server, uri: str) -> str:
+    contents = asyncio.run(server.read_resource(uri))
+    return contents[0].content
+
+
+# ── _load_agent ───────────────────────────────────────────────────────────────
+
+def test_load_agent_returns_string_for_existing_file():
+    content = _load_agent("entry_point.md")
+    assert isinstance(content, str)
+    assert len(content) > 0
+
+
+def test_load_agent_returns_empty_string_for_missing_file():
+    assert _load_agent("nonexistent_file.md") == ""
+
+
+# ── MCP resources registered ──────────────────────────────────────────────────
+
+@pytest.fixture
+def server():
+    return create_server()
+
+
+def test_instructions_resource_is_registered(server):
+    resources = asyncio.run(server.list_resources())
+    uris = [str(r.uri) for r in resources]
+    assert "terminal-hub://instructions" in uris
+
+
+def test_workflow_resources_are_registered(server):
+    resources = asyncio.run(server.list_resources())
+    uris = [str(r.uri) for r in resources]
+    for expected in [
+        "terminal-hub://workflow/init",
+        "terminal-hub://workflow/issue",
+        "terminal-hub://workflow/context",
+        "terminal-hub://workflow/auth",
+    ]:
+        assert expected in uris, f"Missing resource: {expected}"
+
+
+def test_instructions_resource_returns_entry_point_content(server):
+    result = read_resource(server, "terminal-hub://instructions")
+    expected = _load_agent("entry_point.md")
+    assert result == expected
+
+
+def test_instructions_resource_content_non_empty(server):
+    result = read_resource(server, "terminal-hub://instructions")
+    assert len(result) > 0
+
+
+def test_instructions_matches_file_on_disk(server):
+    result = read_resource(server, "terminal-hub://instructions")
+    on_disk = (_AGENTS_DIR / "entry_point.md").read_text()
+    assert result == on_disk
+
+
+# ── workflow files exist on disk ──────────────────────────────────────────────
+
+@pytest.mark.parametrize("filename", [
+    "entry_point.md",
+    "workflow_init.md",
+    "workflow_issue.md",
+    "workflow_context.md",
+    "workflow_auth.md",
+])
+def test_workflow_file_exists(filename):
+    assert (_AGENTS_DIR / filename).exists(), f"Missing: agents/{filename}"
+
+
+def test_workflow_init_resource_has_content(server):
+    result = read_resource(server, "terminal-hub://workflow/init")
+    assert "setup_workspace" in result
+
+
+def test_workflow_issue_resource_has_content(server):
+    result = read_resource(server, "terminal-hub://workflow/issue")
+    assert "create_issue" in result
+
+
+def test_workflow_context_resource_has_content(server):
+    result = read_resource(server, "terminal-hub://workflow/context")
+    assert "get_project_context" in result
+
+
+def test_workflow_auth_resource_has_content(server):
+    result = read_resource(server, "terminal-hub://workflow/auth")
+    assert "check_auth" in result
+
+
+# ── _guidance field in tool responses ────────────────────────────────────────
+
+def test_needs_init_includes_guidance(tmp_path):
+    with patch("terminal_hub.server.get_workspace_root", return_value=tmp_path):
+        s = create_server()
+        result = call(s, "list_issues", {})
+    assert result["status"] == "needs_init"
+    assert result["_guidance"] == "terminal-hub://workflow/init"
+
+
+def test_get_setup_status_uninitialised_includes_guidance(tmp_path):
+    with patch("terminal_hub.server.get_workspace_root", return_value=tmp_path):
+        s = create_server()
+        result = call(s, "get_setup_status", {})
+    assert result["_guidance"] == "terminal-hub://workflow/init"
+
+
+def test_github_unavailable_includes_guidance(tmp_path):
+    (tmp_path / "hub_agents" / "issues").mkdir(parents=True)
+    from terminal_hub.auth import TokenSource
+    with patch("terminal_hub.server.get_workspace_root", return_value=tmp_path), \
+         patch("terminal_hub.server.resolve_token", return_value=(None, TokenSource.NONE)):
+        s = create_server()
+        result = call(s, "create_issue", {"title": "x", "body": "y"})
+    assert result["error"] == "github_unavailable"
+    assert result["_guidance"] == "terminal-hub://workflow/auth"
+
+
+def test_check_auth_unauthenticated_includes_guidance(tmp_path):
+    from terminal_hub.auth import TokenSource
+    with patch("terminal_hub.server.get_workspace_root", return_value=tmp_path), \
+         patch("terminal_hub.server.resolve_token", return_value=(None, TokenSource.NONE)):
+        s = create_server()
+        result = call(s, "check_auth", {})
+    assert result["authenticated"] is False
+    assert result["_guidance"] == "terminal-hub://workflow/auth"
+
+
+def test_verify_auth_failure_includes_guidance(tmp_path):
+    with patch("terminal_hub.server.get_workspace_root", return_value=tmp_path), \
+         patch("terminal_hub.server.verify_gh_cli_auth", return_value=(False, "Not logged in")):
+        s = create_server()
+        result = call(s, "verify_auth", {})
+    assert result["authenticated"] is False
+    assert result["_guidance"] == "terminal-hub://workflow/auth"
+
+
+# ── FastMCP instructions injected at init ─────────────────────────────────────
+
+def test_server_instructions_set():
+    s = create_server()
+    assert s.instructions
+    assert "terminal-hub" in s.instructions
+
+
+# ── .claude/settings.json hook config ────────────────────────────────────────
+
+def test_claude_settings_hook_exists():
+    settings = Path(__file__).parent.parent / ".claude" / "settings.json"
+    assert settings.exists(), ".claude/settings.json not found"
+
+
+def test_claude_settings_has_pretooluse_hook():
+    settings = Path(__file__).parent.parent / ".claude" / "settings.json"
+    data = json.loads(settings.read_text())
+    assert "PreToolUse" in data.get("hooks", {})
+
+
+def test_claude_settings_hook_matches_terminal_hub():
+    settings = Path(__file__).parent.parent / ".claude" / "settings.json"
+    data = json.loads(settings.read_text())
+    hooks = data["hooks"]["PreToolUse"]
+    matchers = [h["matcher"] for h in hooks]
+    assert any("terminal-hub" in m for m in matchers)

--- a/tests/test_server_internals.py
+++ b/tests/test_server_internals.py
@@ -47,14 +47,11 @@ def test_get_github_client_no_repo_returns_error():
 
 # ── terminal_hub_instructions prompt ─────────────────────────────────────────
 
-def test_prompt_returns_instructions(tmp_path):
-    from terminal_hub.prompts import TERMINAL_HUB_INSTRUCTIONS
+def test_server_instructions_loaded_from_entry_point(tmp_path):
+    from terminal_hub.server import _load_agent
     with patch("terminal_hub.server.get_workspace_root", return_value=tmp_path):
         server = create_server()
-
-    prompt_fn = server._prompt_manager.get_prompt("terminal_hub_instructions")
-    result = prompt_fn.fn()
-    assert result == TERMINAL_HUB_INSTRUCTIONS
+    assert server.instructions == _load_agent("entry_point.md")
 
 
 # ── create_issue: local write failure after GitHub success ────────────────────


### PR DESCRIPTION
Closes #11

## What was built

### 1. FastMCP `instructions=` (auto-loaded at init)
`entry_point.md` is passed to `FastMCP(instructions=...)` — Claude Code reads it automatically at connection time, before any tool is called.

### 2. MCP Resources (re-fetchable mid-session)
Five resources registered so Claude can pull any guide at any point:
- `terminal-hub://instructions` — full entry point + tool reference
- `terminal-hub://workflow/init` — initialise a new project
- `terminal-hub://workflow/issue` — create / list / reload issues
- `terminal-hub://workflow/context` — save and load project context
- `terminal-hub://workflow/auth` — auth recovery flow

### 3. `_guidance` field on error responses
`needs_init`, `github_unavailable`, `check_auth` failure, and `verify_auth` failure all include `_guidance: "terminal-hub://workflow/<name>"` so Claude knows exactly which resource to fetch.

### 4. `agents/` workflow files
`entry_point.md` + four focused `workflow_*.md` files — each maps a trigger to concrete tool-call steps.

### 5. `.claude/settings.json` PreToolUse hook
Fires before every `terminal-hub:*` tool call, printing a one-line reminder to refer to instructions.

## Test plan
- [ ] 25 new tests in `test_instructions_hook.py` — all pass
- [ ] `server.instructions` matches `entry_point.md` on disk
- [ ] All 5 resource URIs registered and return correct content
- [ ] `_guidance` present on needs_init, github_unavailable, auth failure responses
- [ ] All `agents/workflow_*.md` files exist
- [ ] `.claude/settings.json` has PreToolUse hook matching `terminal-hub:*`
- [ ] 155 total tests, 98% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)