### PR TITLE
feat: structured project docs — feature-area design dictionary + lookup_feature_section

### DIFF
--- a/plugins/github_planner/__init__.py
+++ b/plugins/github_planner/__init__.py
@@ -7,6 +7,7 @@ import ast
 import hashlib
 import json
 import os
+import re
 import time
 from datetime import date
 from pathlib import Path
@@ -48,7 +49,12 @@ _ANALYSIS_CACHE: dict[str, dict] = {}
 
 _PROJECT_DOCS_CACHE: dict[str, dict] = {}
 # Key: "owner/repo"
-# {"summary": str | None, "detail": str | None, "loaded_at": float}
+# {
+#   "summary":    str | None,
+#   "detail":     str | None,
+#   "_sections":  dict[str, str] | None,  # parsed H2 sections of detail
+#   "loaded_at":  float,
+# }
 
 # ── Guidance URIs ─────────────────────────────────────────────────────────────
 _G_INIT    = "terminal-hub://workflow/init"
@@ -523,9 +529,11 @@ def _do_save_project_docs(summary_md: str, detail_md: str, repo: str | None = No
             return {"error": "write_failed", "message": str(exc), "_hook": None}
 
     resolved = _resolve_repo(repo) or "unknown"
+    # Reset cache fully (sections may have changed)
     _PROJECT_DOCS_CACHE[resolved] = {
         "summary": summary_md,
         "detail": detail_md,
+        "_sections": None,  # will be re-parsed on next lookup_feature_section call
         "loaded_at": time.time(),
     }
     # #61 — invalidate session header so next call reflects fresh docs
@@ -581,10 +589,113 @@ def _do_docs_exist(repo: str | None = None) -> dict:
     if summary_exists:
         age_hours = (time.time() - summary_path.stat().st_mtime) / 3600
 
+    # Surface section headings so callers can decide which section to load
+    sections: list[str] = []
+    if detail_exists:
+        text = detail_path.read_text(encoding="utf-8")
+        sections = list(_parse_h2_sections(text).keys())
+
     return {
         "summary_exists": summary_exists,
         "detail_exists": detail_exists,
         "summary_age_hours": age_hours,
+        "sections": sections,
+    }
+
+
+# ── Section-level helpers ─────────────────────────────────────────────────────
+
+
+def _parse_h2_sections(text: str) -> dict[str, str]:
+    """Parse markdown text into {heading: content} for every H2 section."""
+    sections: dict[str, str] = {}
+    current_heading: str | None = None
+    current_lines: list[str] = []
+    for line in text.splitlines():
+        m = re.match(r"^##\s+(.+)", line)
+        if m:
+            if current_heading is not None:
+                sections[current_heading] = "\n".join(current_lines).strip()
+            current_heading = m.group(1).strip()
+            current_lines = []
+        else:
+            if current_heading is not None:
+                current_lines.append(line)
+    if current_heading is not None:
+        sections[current_heading] = "\n".join(current_lines).strip()
+    return sections
+
+
+def _do_lookup_feature_section(feature: str, repo: str | None = None) -> dict:
+    """Return the project_detail.md section whose H2 heading best matches `feature`.
+
+    Matching order: exact → substring → first prefix match.
+    Also returns global_rules from project_summary.md and the full list of
+    available feature headings so Claude can suggest adding a missing section.
+    """
+    resolved = _resolve_repo(repo) or "unknown"
+    entry = _PROJECT_DOCS_CACHE.setdefault(resolved, {})
+
+    # --- section cache ---
+    sections: dict[str, str] | None = entry.get("_sections")
+    if sections is None:
+        root = get_workspace_root()
+        docs_dir = _gh_planner_docs_dir(root)
+        detail_path = docs_dir / "project_detail.md"
+        if not detail_path.exists():
+            return {
+                "matched": False,
+                "available_features": [],
+                "reason": "project_detail.md not found — run analyze or save_project_docs first",
+            }
+        sections = _parse_h2_sections(detail_path.read_text(encoding="utf-8"))
+        entry["_sections"] = sections
+
+    available = list(sections.keys())
+    feature_lower = feature.lower()
+
+    matched_key: str | None = None
+    # 1. exact
+    for k in sections:
+        if k.lower() == feature_lower:
+            matched_key = k
+            break
+    # 2. substring
+    if matched_key is None:
+        for k in sections:
+            if feature_lower in k.lower() or k.lower() in feature_lower:
+                matched_key = k
+                break
+    # 3. first-word prefix
+    if matched_key is None:
+        first_word = feature_lower.split()[0] if feature_lower.split() else ""
+        for k in sections:
+            if first_word and k.lower().startswith(first_word):
+                matched_key = k
+                break
+
+    # --- global rules (project_summary.md, cached) ---
+    global_rules: str | None = entry.get("summary")
+    if global_rules is None:
+        root = get_workspace_root()
+        sp = _gh_planner_docs_dir(root) / "project_summary.md"
+        if sp.exists():
+            global_rules = sp.read_text(encoding="utf-8")
+            entry["summary"] = global_rules
+
+    if matched_key is None:
+        return {
+            "matched": False,
+            "available_features": available,
+            "global_rules": global_rules,
+        }
+
+    return {
+        "matched": True,
+        "feature": matched_key,
+        "section": sections[matched_key],
+        "global_rules": global_rules,
+        "available_features": available,
     }
 
 
@@ -770,10 +881,11 @@ def _do_analyze_repo_full(repo: str | None = None) -> dict:
 # ── get_session_header ─────────────────────────────────────────────────────────
 
 def _do_get_session_header() -> dict:
-    """Return a ≤80-token context blob for session start. Cached after first call.
+    """Return a ≤120-token context blob for session start. Cached after first call.
 
-    Tells Claude whether project docs exist, how fresh they are, and a one-line
-    summary title. Claude loads the full summary only when planning context is needed.
+    Tells Claude whether project docs exist, how fresh they are, a one-line
+    summary title, and the list of feature-area sections in project_detail.md.
+    Claude loads full summary/section only when planning context is needed.
     """
     if _SESSION_HEADER_CACHE:
         return _SESSION_HEADER_CACHE
@@ -781,6 +893,7 @@ def _do_get_session_header() -> dict:
     root = get_workspace_root()
     docs_dir = _gh_planner_docs_dir(root)
     summary_path = docs_dir / "project_summary.md"
+    detail_path = docs_dir / "project_detail.md"
 
     if not summary_path.exists():
         _SESSION_HEADER_CACHE.update({"docs": False})
@@ -789,11 +902,17 @@ def _do_get_session_header() -> dict:
     age_h = (time.time() - summary_path.stat().st_mtime) / 3600
     first_line = summary_path.read_text(encoding="utf-8").splitlines()[0].lstrip("# ").strip()
 
+    # Surface section index so Claude knows which feature areas have detail
+    sections: list[str] = []
+    if detail_path.exists():
+        sections = list(_parse_h2_sections(detail_path.read_text(encoding="utf-8")).keys())
+
     _SESSION_HEADER_CACHE.update({
         "docs": True,
         "age_hours": round(age_h, 1),
         "title": first_line,
         "stale": age_h > 168,
+        "sections": sections,
     })
     return _SESSION_HEADER_CACHE
 
@@ -977,9 +1096,28 @@ def register(mcp) -> None:
     def docs_exist(repo: str | None = None) -> dict:
         """Check whether project_summary.md and project_detail.md exist on disk.
 
-        Returns {summary_exists, detail_exists, summary_age_hours}.
+        Returns {summary_exists, detail_exists, summary_age_hours, sections}.
+        sections: list of H2 headings from project_detail.md — use to decide
+        whether a relevant feature section exists before calling lookup_feature_section.
         """
         return _do_docs_exist(repo)
+
+    @mcp.tool()
+    def lookup_feature_section(feature: str, repo: str | None = None) -> dict:
+        """Return the project_detail.md section whose heading best matches `feature`.
+
+        Matching order: exact → substring → prefix. Uses section-level cache so
+        only the matching section (not the full detail doc) is returned to Claude.
+
+        Returns:
+          matched=True:  {feature, section, global_rules, available_features}
+          matched=False: {available_features, global_rules, reason?}
+
+        Call this BEFORE drafting any issue body when project_detail.md exists.
+        If matched=False, show available_features and ask the user whether to add
+        rules for this feature before proceeding.
+        """
+        return _do_lookup_feature_section(feature, repo)
 
     # ── Efficient single-call repo analysis ────────────────────────────────────
 

--- a/plugins/github_planner/commands/github-planner.md
+++ b/plugins/github_planner/commands/github-planner.md
@@ -25,7 +25,7 @@ Ask:
 > a) GitHub URL or `owner/repo`  b) Use configured repo  c) Brand-new repo
 
 - **(b)**: read env, skip to Step 3
-- **(c)**: ask name/language/description → skip analysis → Step 5
+- **(c)**: ask name/language/description → skip analysis → Step 5 (no doc lookup)
 - **(a)**: call `setup_workspace(github_repo=...)` if not already set
 
 ---
@@ -41,9 +41,12 @@ If analyzing → run the **analyze sub-command** workflow (`/t-h:github-planner/
 
 ---
 
-## Step 4 — Load project context (silent)
+## Step 4 — Load summary (silent)
 
 Call `load_project_docs(doc="summary")`. Absorb silently — do not show to user.
+Note the `Feature Sections` line in the summary: this is the index of available
+detail sections. Load individual sections via `lookup_feature_section` only when
+the user discusses a topic that matches a section heading.
 
 ---
 
@@ -52,7 +55,12 @@ Call `load_project_docs(doc="summary")`. Absorb silently — do not show to user
 Say: **"Let me know any plans for this!"**
 
 - Use project summary as background context (silent)
-- Load `project_detail.md` only when user references a specific file/module
+- When the user describes a feature or task:
+  - If `session_header.sections` (or `docs_exist.sections`) contains a matching area,
+    call `lookup_feature_section(feature="{area}")` and use the returned
+    `section` to inform issue scope and AC.
+  - Do NOT load `project_detail.md` in full — always use `lookup_feature_section`
+    with a specific feature name.
 - Ask one clarifying question at a time
 - Propose a breakdown when the user describes enough: epics → issues
 - When ready, show a one-line preview list:
@@ -67,10 +75,19 @@ Say: **"Let me know any plans for this!"**
 ## Step 6 — Issue creation
 
 After approval:
-1. Call `draft_issue(title, body, labels, assignees)` for each — **silent**
-2. Show count: "Drafted {N} issues. Push to GitHub? (yes / review first)"
-3. If yes: call `submit_issue(slug)` for each — **silent**
-4. Say: **"Let me know any plans for this!"**
+1. For each planned issue: call `lookup_feature_section(feature="...")` if not already
+   done for that area. Use returned section + global_rules in the issue body.
+2. Call `draft_issue(title, body, labels, assignees)` for each — **silent**
+3. Show count: "Drafted {N} issues. Push to GitHub? (yes / review first)"
+4. If yes: call `submit_issue(slug)` for each — **silent**
+5. **Auto-update project docs** (only for new features, not bug fixes or refactors):
+   - If any drafted issue introduces a new feature area not in `docs_exist.sections`:
+     call `load_project_docs(doc="detail")`, append a new H2 section for that area
+     with what was planned (future-tense guidelines), then call `save_project_docs`.
+   - If an existing section was extended: call `lookup_feature_section`, merge the
+     planned work into Extension Guidelines, save updated docs.
+   - Bug fix / refactor issues → **do not update project docs**.
+6. Say: **"Let me know any plans for this!"**
 
 ---
 

--- a/plugins/github_planner/commands/github-planner/analyze.md
+++ b/plugins/github_planner/commands/github-planner/analyze.md
@@ -8,9 +8,61 @@ Repo analysis workflow:
 2. Call `docs_exist`. If summary < 7 days old, ask: "Project notes exist ({N:.0f}h old). Re-analyze? (yes / use existing)"
 3. If analyzing:
    a. Call `analyze_repo_full()` → announce: "Found {total_files} files, fetched {fetched} ({skipped_unchanged} unchanged)."
-   b. From the returned `file_index`, generate:
-      - `project_summary.md` (≤400 tokens: description + tech stack table + pitfalls)
-      - `project_detail.md` (per-file: purpose, exports, behaviour, workflows)
-      Use `file_index[].exports`, `file_index[].headings`, `file_index[].module_doc` — never request raw file contents.
+   b. From the returned `file_index`, generate two documents using the formats below.
+      Use `file_index[].exports`, `file_index[].headings`, `file_index[].module_doc` to derive
+      content — never request raw file contents. Group files by feature area.
    c. Call `save_project_docs(summary_md, detail_md)`.
 4. Say: "Analysis complete. Let me know any plans for this!"
+
+---
+
+## project_summary.md format (≤500 tokens)
+
+```
+# {Project name}
+{1–2 sentence description}
+
+## Tech Stack
+| Layer | Technology |
+|-------|------------|
+
+## Implemented Features
+- {Feature A}: {one-line description}
+- {Feature B}: {one-line description}
+
+## Design Principles
+- {Principle extracted from recurring code patterns}
+
+## Known Pitfalls
+- {Non-obvious constraint or gotcha}
+
+## Feature Sections
+{Comma-separated list matching the H2 headings in project_details.md}
+```
+
+The **Feature Sections** line is an index. It lets Claude decide whether to call
+`lookup_feature_section` without loading the full detail doc.
+
+---
+
+## project_details.md format (feature-area design dictionary)
+
+One H2 section per distinct feature area (e.g. "Issue Management", "Plugin Framework",
+"Auth", "Session Context"). Group related files under the same heading.
+
+```markdown
+## {Feature Area Name}
+
+### Existing Design
+- Data model / storage path
+- Key functions/tools and their contracts (inputs → outputs)
+- Notable constraints or invariants
+
+### Extension Guidelines
+- Patterns new features in this area must follow
+- Anti-patterns already observed — avoid these
+- Where to add new code (module / file)
+```
+
+Each section is independently retrievable via `lookup_feature_section`. Keep sections
+focused; a file may appear in multiple sections if relevant.

--- a/plugins/github_planner/commands/github-planner/create-issue.md
+++ b/plugins/github_planner/commands/github-planner/create-issue.md
@@ -6,11 +6,44 @@
 Guided single-issue workflow:
 
 1. If workspace not initialised, call `get_setup_status` and handle setup first.
+
 2. Ask: "What's the issue? Describe the bug, feature, or task."
+
 3. Listen. Ask one clarifying question if scope is unclear.
-4. Propose: title (one line) + body (structured: what/why/acceptance criteria).
-5. Show preview. Ask: "Create this? (yes / edit)"
-6. On yes: call `draft_issue(title, body, labels, assignees)`.
-7. Ask: "Push to GitHub now? (yes / save locally for now)"
-8. If yes: call `submit_issue(slug)`.
-9. Say: "Let me know any plans for this!"
+
+4. **Project context lookup** (skip if workspace is brand-new with no docs):
+   - Call `docs_exist`. If `summary_exists: false` → skip to step 5.
+   - Identify which feature area this issue belongs to from the user's description.
+   - Call `lookup_feature_section(feature="{area}")`.
+   - If `matched: true`:
+     - Use `section` content (Existing Design + Extension Guidelines) as the
+       basis for **Acceptance Criteria**.
+     - Use `global_rules` to populate a **Constraints** section.
+   - If `matched: false`:
+     - Silently note `available_features` — do not ask the user about it now.
+     - Draft without feature-specific AC; proceed normally.
+
+5. Propose: title (one line, imperative) + body:
+   ```
+   ## What
+   {What the issue is asking for}
+
+   ## Why
+   {Context or motivation}
+
+   ## Acceptance Criteria
+   - [ ] {Derived from section content if matched, otherwise inferred}
+
+   ## Constraints
+   {From global_rules; omit if no docs exist}
+   ```
+
+6. Show preview. Ask: "Create this? (yes / edit)"
+
+7. On yes: call `draft_issue(title, body, labels, assignees)`.
+
+8. Ask: "Push to GitHub now? (yes / save locally for now)"
+
+9. If yes: call `submit_issue(slug)`.
+
+10. Say: "Let me know any plans for this!"

--- a/tests/test_repo_analysis.py
+++ b/tests/test_repo_analysis.py
@@ -702,3 +702,165 @@ def test_analyze_repo_full_and_get_session_header_registered(workspace):
     tool_names = {t.name for t in server._tool_manager.list_tools()}
     assert "analyze_repo_full" in tool_names
     assert "get_session_header" in tool_names
+
+
+# ── _parse_h2_sections + _do_lookup_feature_section ─────────────────────────
+
+from plugins.github_planner import _parse_h2_sections, _do_lookup_feature_section
+
+
+def test_parse_h2_sections_basic():
+    text = "## Issue Management\ncontent A\n## Plugin Framework\ncontent B"
+    sections = _parse_h2_sections(text)
+    assert list(sections.keys()) == ["Issue Management", "Plugin Framework"]
+    assert sections["Issue Management"] == "content A"
+    assert sections["Plugin Framework"] == "content B"
+
+
+def test_parse_h2_sections_empty():
+    assert _parse_h2_sections("") == {}
+    assert _parse_h2_sections("# H1 only\nno h2") == {}
+
+
+def test_parse_h2_sections_h3_inside_section():
+    text = "## Auth\n### Existing\nstuff\n### Guidelines\nmore"
+    sections = _parse_h2_sections(text)
+    assert "Auth" in sections
+    assert "### Existing" in sections["Auth"]
+
+
+def test_lookup_feature_section_no_detail_doc(workspace):
+    with patch("plugins.github_planner.get_workspace_root", return_value=workspace):
+        result = _do_lookup_feature_section("Issue Management")
+    assert result["matched"] is False
+    assert "project_detail.md not found" in result["reason"]
+
+
+def test_lookup_feature_section_exact_match(workspace):
+    docs_dir = _gh_planner_docs_dir(workspace)
+    docs_dir.mkdir(parents=True)
+    (docs_dir / "project_detail.md").write_text(
+        "## Issue Management\nrules A\n## Auth\nrules B"
+    )
+    with patch("plugins.github_planner.get_workspace_root", return_value=workspace):
+        result = _do_lookup_feature_section("Issue Management")
+    assert result["matched"] is True
+    assert result["feature"] == "Issue Management"
+    assert "rules A" in result["section"]
+
+
+def test_lookup_feature_section_case_insensitive(workspace):
+    docs_dir = _gh_planner_docs_dir(workspace)
+    docs_dir.mkdir(parents=True)
+    (docs_dir / "project_detail.md").write_text("## Issue Management\nrules A")
+    with patch("plugins.github_planner.get_workspace_root", return_value=workspace):
+        result = _do_lookup_feature_section("issue management")
+    assert result["matched"] is True
+
+
+def test_lookup_feature_section_substring_match(workspace):
+    docs_dir = _gh_planner_docs_dir(workspace)
+    docs_dir.mkdir(parents=True)
+    (docs_dir / "project_detail.md").write_text("## Issue Management\nrules A")
+    with patch("plugins.github_planner.get_workspace_root", return_value=workspace):
+        result = _do_lookup_feature_section("issue")
+    assert result["matched"] is True
+    assert result["feature"] == "Issue Management"
+
+
+def test_lookup_feature_section_no_match_returns_available(workspace):
+    docs_dir = _gh_planner_docs_dir(workspace)
+    docs_dir.mkdir(parents=True)
+    (docs_dir / "project_detail.md").write_text("## Auth\nrules")
+    with patch("plugins.github_planner.get_workspace_root", return_value=workspace):
+        result = _do_lookup_feature_section("Nonexistent Feature")
+    assert result["matched"] is False
+    assert "Auth" in result["available_features"]
+
+
+def test_lookup_feature_section_includes_global_rules(workspace):
+    docs_dir = _gh_planner_docs_dir(workspace)
+    docs_dir.mkdir(parents=True)
+    (docs_dir / "project_summary.md").write_text("# My Project\nGlobal rule 1")
+    (docs_dir / "project_detail.md").write_text("## Auth\nrules")
+    with patch("plugins.github_planner.get_workspace_root", return_value=workspace):
+        result = _do_lookup_feature_section("Auth")
+    assert result["matched"] is True
+    assert "Global rule 1" in result["global_rules"]
+
+
+def test_lookup_feature_section_uses_section_cache(workspace):
+    """Second call should hit _sections cache; _PROJECT_DOCS_CACHE entry is populated."""
+    docs_dir = _gh_planner_docs_dir(workspace)
+    docs_dir.mkdir(parents=True)
+    (docs_dir / "project_detail.md").write_text("## Auth\nrules")
+
+    with patch("plugins.github_planner.get_workspace_root", return_value=workspace):
+        r1 = _do_lookup_feature_section("Auth")
+        # Delete the file — second call must still succeed via cache
+        (docs_dir / "project_detail.md").unlink()
+        r2 = _do_lookup_feature_section("Auth")
+
+    assert r1["matched"] is True
+    assert r2["matched"] is True
+    assert r1["section"] == r2["section"]
+
+
+def test_save_project_docs_clears_sections_cache(workspace):
+    docs_dir = _gh_planner_docs_dir(workspace)
+    docs_dir.mkdir(parents=True)
+    (workspace / "hub_agents").mkdir(exist_ok=True)
+    (workspace / ".gitignore").write_text("")
+    with patch("plugins.github_planner.get_workspace_root", return_value=workspace):
+        # Populate section cache via lookup
+        (docs_dir / "project_detail.md").write_text("## Auth\nold rules")
+        _do_lookup_feature_section("Auth")
+        # Now save new docs
+        _do_save_project_docs("new summary", "## NewArea\nnew rules")
+        # sections cache should be cleared
+        resolved = pg._resolve_repo(None) or "unknown"
+        entry = pg._PROJECT_DOCS_CACHE.get(resolved, {})
+        assert entry.get("_sections") is None
+
+
+def test_docs_exist_returns_sections(workspace):
+    docs_dir = _gh_planner_docs_dir(workspace)
+    docs_dir.mkdir(parents=True)
+    (docs_dir / "project_summary.md").write_text("# P")
+    (docs_dir / "project_detail.md").write_text("## Auth\nrules\n## Session\nmore")
+    with patch("plugins.github_planner.get_workspace_root", return_value=workspace):
+        result = _do_docs_exist()
+    assert result["sections"] == ["Auth", "Session"]
+
+
+def test_docs_exist_sections_empty_when_no_detail(workspace):
+    with patch("plugins.github_planner.get_workspace_root", return_value=workspace):
+        result = _do_docs_exist()
+    assert result["sections"] == []
+
+
+def test_get_session_header_includes_sections(workspace):
+    docs_dir = _gh_planner_docs_dir(workspace)
+    docs_dir.mkdir(parents=True)
+    (docs_dir / "project_summary.md").write_text("# My Project\ntext")
+    (docs_dir / "project_detail.md").write_text("## Issue Management\nr\n## Auth\nr")
+    with patch("plugins.github_planner.get_workspace_root", return_value=workspace):
+        result = _do_get_session_header()
+    assert result["docs"] is True
+    assert result["sections"] == ["Issue Management", "Auth"]
+
+
+def test_get_session_header_no_detail_sections_empty(workspace):
+    docs_dir = _gh_planner_docs_dir(workspace)
+    docs_dir.mkdir(parents=True)
+    (docs_dir / "project_summary.md").write_text("# My Project")
+    with patch("plugins.github_planner.get_workspace_root", return_value=workspace):
+        result = _do_get_session_header()
+    assert result["sections"] == []
+
+
+def test_lookup_feature_section_tool_registered(workspace):
+    with patch("terminal_hub.server.get_workspace_root", return_value=workspace):
+        server = create_server()
+    tool_names = {t.name for t in server._tool_manager.list_tools()}
+    assert "lookup_feature_section" in tool_names


### PR DESCRIPTION
## Summary

- **`project_details.md` redesigned**: from a per-file code map to a per-feature-area design dictionary. Each H2 section has "Existing Design" (what's built) + "Extension Guidelines" (how to extend it) — future-oriented, not just descriptive.
- **New `lookup_feature_section(feature)` tool**: section-level retrieval (exact → substring → prefix match), cached per-feature in `_PROJECT_DOCS_CACHE["_sections"]`. Returns matched section + global_rules in one call.
- **`get_session_header` + `docs_exist`** now return `sections` list — the lightweight routing index that lets Claude identify relevant feature areas without loading the full detail doc.
- **`create-issue.md` and `github-planner.md`** updated: `docs_exist` guard for new repos; `lookup_feature_section` called before drafting; planner Step 6 auto-updates docs for new features only (skips bug/refactor).
- **`analyze.md`** updated to generate the new format (feature-area dict instead of per-file).
- 16 new tests; 532 total, 96.76% coverage.

## Research backing

- Stanford "lost-in-the-middle" (0.95): summary always first; section-level retrieval prevents middle-context degradation
- Anthropic two-tier pattern (0.85): compact summary as routing layer; load detail only on named feature reference  
- Section-level chunking (Pinecone/LlamaIndex, 0.85): H2-header splits are optimal for known-structure design dicts

## Related issues

Closes #64. Tracked follow-ups: #65 (planner update criteria), #66 (Feature Sections staleness), #67 (sections token cap), #68 (legacy create.md), #69 (mtime cache), #70 (conditional summary load).

## Test plan

- [ ] `pytest tests/` — 532 passing, 96.76% coverage
- [ ] `lookup_feature_section("issue")` → matches "Issue Management" via substring
- [ ] `get_session_header` returns `sections: ["Issue Management", "Auth"]` when detail doc has those H2s
- [ ] `save_project_docs` clears `_sections` cache; next `lookup_feature_section` re-parses

🤖 Generated with [Claude Code](https://claude.com/claude-code)