### PR TITLE
fix: mtime invalidation, sections cap, stale index, create.md guard (#66-#69)

### DIFF
--- a/extensions/github_planner/__init__.py
+++ b/extensions/github_planner/__init__.py
@@ -652,20 +652,23 @@ def _do_lookup_feature_section(feature: str, repo: str | None = None) -> dict:
     resolved = _resolve_repo(repo) or "unknown"
     entry = _PROJECT_DOCS_CACHE.setdefault(resolved, {})
 
-    # --- section cache ---
+    # --- section cache (with mtime-based invalidation) ---
+    root = get_workspace_root()
+    docs_dir = _gh_planner_docs_dir(root)
+    detail_path = docs_dir / "project_detail.md"
+    if not detail_path.exists():
+        return {
+            "matched": False,
+            "available_features": [],
+            "reason": "project_detail.md not found — run analyze or save_project_docs first",
+        }
+    current_mtime = detail_path.stat().st_mtime
+    cached_mtime: float | None = entry.get("_sections_mtime")
     sections: dict[str, str] | None = entry.get("_sections")
-    if sections is None:
-        root = get_workspace_root()
-        docs_dir = _gh_planner_docs_dir(root)
-        detail_path = docs_dir / "project_detail.md"
-        if not detail_path.exists():
-            return {
-                "matched": False,
-                "available_features": [],
-                "reason": "project_detail.md not found — run analyze or save_project_docs first",
-            }
+    if sections is None or cached_mtime != current_mtime:
         sections = _parse_h2_sections(detail_path.read_text(encoding="utf-8"))
         entry["_sections"] = sections
+        entry["_sections_mtime"] = current_mtime
 
     available = list(sections.keys())
     feature_lower = feature.lower()
@@ -1019,17 +1022,26 @@ def _do_get_session_header() -> dict:
     first_line = summary_path.read_text(encoding="utf-8").splitlines()[0].lstrip("# ").strip()
 
     # Surface section index so Claude knows which feature areas have detail
+    # Capped at 10 entries to stay within the ≤120-token budget (#67)
+    _MAX_SECTIONS_IN_HEADER = 10
     sections: list[str] = []
+    total_sections = 0
     if detail_path.exists():
-        sections = list(_parse_h2_sections(detail_path.read_text(encoding="utf-8")).keys())
+        all_sections = list(_parse_h2_sections(detail_path.read_text(encoding="utf-8")).keys())
+        total_sections = len(all_sections)
+        sections = all_sections[:_MAX_SECTIONS_IN_HEADER]
 
-    _SESSION_HEADER_CACHE.update({
+    result: dict = {
         "docs": True,
         "age_hours": round(age_h, 1),
         "title": first_line,
         "stale": age_h > 168,
         "sections": sections,
-    })
+    }
+    if total_sections > _MAX_SECTIONS_IN_HEADER:
+        result["sections_truncated"] = True
+        result["total_sections"] = total_sections
+    _SESSION_HEADER_CACHE.update(result)
     return _SESSION_HEADER_CACHE
 
 

--- a/extensions/github_planner/commands/create.md
+++ b/extensions/github_planner/commands/create.md
@@ -10,7 +10,15 @@
    - **labels** — optional (e.g. `["bug", "priority-high"]`)
    - **assignees** — optional GitHub usernames
 
-2. Call `create_issue(title=..., body=..., labels=..., assignees=...)`
+2. Call `docs_exist()` to check for project context:
+   - If `summary_exists: false` → skip doc lookup, proceed with user-provided info
+   - If `summary_exists: true` and sections list is non-empty:
+     - Infer the relevant feature area from the issue title
+     - Call `lookup_feature_section(feature="...")` to get design constraints
+     - If `matched: true`: use `section` to inform AC and `global_rules` for constraints
+     - If `matched: false`: note the available sections but don't block creation
+
+3. Call `create_issue(title=..., body=..., labels=..., assignees=...)`
 
 3. On success, confirm:
    > "Created issue #`{issue_number}`: `{url}`

--- a/extensions/github_planner/commands/github-planner/analyze.md
+++ b/extensions/github_planner/commands/github-planner/analyze.md
@@ -35,13 +35,10 @@ Repo analysis workflow:
 
 ## Known Pitfalls
 - {Non-obvious constraint or gotcha}
-
-## Feature Sections
-{Comma-separated list matching the H2 headings in project_details.md}
 ```
 
-The **Feature Sections** line is an index. It lets Claude decide whether to call
-`lookup_feature_section` without loading the full detail doc.
+<!-- NOTE: Do NOT add a "Feature Sections" line — it goes stale when project_detail.md is edited.
+     Use get_session_header() which returns the live sections list from project_detail.md. -->
 
 ---
 

--- a/tests/test_repo_analysis.py
+++ b/tests/test_repo_analysis.py
@@ -864,3 +864,56 @@ def test_lookup_feature_section_tool_registered(workspace):
         server = create_server()
     tool_names = {t.name for t in server._tool_manager.list_tools()}
     assert "lookup_feature_section" in tool_names
+
+
+# ── mtime cache invalidation (#69) ────────────────────────────────────────────
+
+def test_lookup_feature_section_invalidates_cache_on_file_change(workspace):
+    """Editing project_detail.md on disk should cause the next lookup to re-parse."""
+    docs_dir = _gh_planner_docs_dir(workspace)
+    docs_dir.mkdir(parents=True)
+    detail = docs_dir / "project_detail.md"
+    detail.write_text("## Auth\nrules")
+    with patch("extensions.github_planner.get_workspace_root", return_value=workspace):
+        r1 = _do_lookup_feature_section("Auth")
+    assert r1["matched"] is True
+
+    # Simulate external edit — write new content and bump mtime
+    import time as _time
+    _time.sleep(0.01)
+    detail.write_text("## NewFeature\nnew rules")
+    # Touch mtime explicitly to ensure it differs
+    detail.touch()
+
+    with patch("extensions.github_planner.get_workspace_root", return_value=workspace):
+        r2 = _do_lookup_feature_section("NewFeature")
+    assert r2["matched"] is True
+    assert "Auth" not in r2.get("available_features", [])
+
+
+# ── session_header sections cap (#67) ─────────────────────────────────────────
+
+def test_get_session_header_caps_sections_at_10(workspace):
+    """session_header sections list is capped at 10 entries for large repos."""
+    docs_dir = _gh_planner_docs_dir(workspace)
+    docs_dir.mkdir(parents=True)
+    (docs_dir / "project_summary.md").write_text("# Big Project")
+    # Write 15 H2 sections
+    sections_md = "\n".join(f"## Section{i}\ncontent" for i in range(15))
+    (docs_dir / "project_detail.md").write_text(sections_md)
+    with patch("extensions.github_planner.get_workspace_root", return_value=workspace):
+        result = _do_get_session_header()
+    assert len(result["sections"]) == 10
+    assert result.get("sections_truncated") is True
+    assert result.get("total_sections") == 15
+
+
+def test_get_session_header_no_truncation_when_few_sections(workspace):
+    docs_dir = _gh_planner_docs_dir(workspace)
+    docs_dir.mkdir(parents=True)
+    (docs_dir / "project_summary.md").write_text("# My Project")
+    (docs_dir / "project_detail.md").write_text("## Auth\nr\n## Session\nr")
+    with patch("extensions.github_planner.get_workspace_root", return_value=workspace):
+        result = _do_get_session_header()
+    assert len(result["sections"]) == 2
+    assert "sections_truncated" not in result


### PR DESCRIPTION
## Summary
- **#69** `_sections` cache now invalidated on `project_detail.md` mtime change (not just on save)
- **#67** `get_session_header` caps `sections` list at 10; adds `sections_truncated` + `total_sections` fields
- **#66** `analyze.md` format drops stale "Feature Sections" index line (use `get_session_header()` instead)
- **#68** Legacy `create.md` gains `docs_exist` guard + `lookup_feature_section` step before issue creation

## Test plan
- [x] 567 tests pass, 96% coverage
- [x] `test_lookup_feature_section_invalidates_cache_on_file_change`
- [x] `test_get_session_header_caps_sections_at_10` / `test_get_session_header_no_truncation_when_few_sections`

Closes #66, #67, #68, #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)