### PR TITLE
feat: new-repo workflow + existing docs detection (#83 #84)

### DIFF
--- a/extensions/github_planner/__init__.py
+++ b/extensions/github_planner/__init__.py
@@ -1304,6 +1304,84 @@ def _do_list_pending_drafts() -> dict:
     return {"pending_drafts": pending, "count": len(pending)}
 
 
+# ── Existing docs detection (#84) ─────────────────────────────────────────────
+
+_DOC_LIKE_PATTERNS = frozenset([
+    "readme", "design", "architecture", "spec", "contributing",
+    "changelog", "changes", "history", "docs/", "documentation/",
+])
+
+
+def detect_existing_docs(file_index: list[dict]) -> list[dict]:
+    """From analyze_repo_full file_index, return doc-like .md files.
+
+    Matches top-level README/DESIGN/ARCHITECTURE or files under docs/ directory.
+    Returns list of {path, size} dicts for Claude to present to the user.
+    """
+    results = []
+    for f in file_index:
+        path: str = f.get("path", "").lower()
+        if not path.endswith(".md"):
+            continue
+        base = path.rsplit("/", 1)[-1].rstrip(".md").lower() if "/" in path else path.rstrip(".md").lower()
+        if any(pat in path or base.startswith(pat.rstrip("/")) for pat in _DOC_LIKE_PATTERNS):
+            results.append({"path": f["path"], "size": f.get("size", 0)})
+    return results
+
+
+def _do_save_docs_strategy(
+    strategy: str,
+    referred_docs: list[str] | None = None,
+) -> dict:
+    """Persist existing-docs strategy to hub_agents/extensions/gh_planner/docs_strategy.json (#84).
+
+    strategy: one of 'refer', 'overwrite', 'merge', 'ignore'
+    referred_docs: list of file paths (only meaningful for strategy='refer')
+    """
+    root = get_workspace_root()
+    if err := ensure_initialized(root):
+        return err
+
+    valid = {"refer", "overwrite", "merge", "ignore"}
+    if strategy not in valid:
+        return {"error": "invalid_strategy", "message": f"strategy must be one of {sorted(valid)}"}
+
+    docs_dir = _gh_planner_docs_dir(root)
+    docs_dir.mkdir(parents=True, exist_ok=True)
+    strategy_path = docs_dir / "docs_strategy.json"
+
+    data: dict = {"strategy": strategy}
+    if strategy == "refer" and referred_docs:
+        data["referred_docs"] = referred_docs
+
+    tmp = strategy_path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    import os as _os4; _os4.replace(tmp, strategy_path)
+
+    return {
+        "saved": True,
+        "strategy": strategy,
+        "file": str(strategy_path.relative_to(root)),
+        "_display": f"✓ Docs strategy saved: {strategy}",
+    }
+
+
+def _do_load_docs_strategy() -> dict:
+    """Load existing-docs strategy from disk, or return default (#84)."""
+    root = get_workspace_root()
+    if err := ensure_initialized(root):
+        return err
+
+    strategy_path = _gh_planner_docs_dir(root) / "docs_strategy.json"
+    if not strategy_path.exists():
+        return {"strategy": None, "referred_docs": []}
+    try:
+        data = json.loads(strategy_path.read_text(encoding="utf-8"))
+        return {"strategy": data.get("strategy"), "referred_docs": data.get("referred_docs", [])}
+    except (json.JSONDecodeError, OSError):
+        return {"strategy": None, "referred_docs": []}
+
+
 # ── Plugin unload ─────────────────────────────────────────────────────────────
 
 # All volatile cache files owned by gh_planner (project docs and issues are NOT included)
@@ -1547,6 +1625,21 @@ def register(mcp) -> None:
         """Read project_description.md and/or architecture_design.md from hub_agents/.
         doc_key: 'project_description', 'architecture', or 'all'."""
         return _do_get_project_context(doc_key)
+
+    @mcp.tool()
+    def save_docs_strategy(strategy: str, referred_docs: list[str] | None = None) -> dict:
+        """Persist how to handle existing .md docs found during repo analysis (#84).
+
+        strategy: 'refer' | 'overwrite' | 'merge' | 'ignore'
+        referred_docs: paths of docs to use as context (only for strategy='refer').
+        Saved to hub_agents/extensions/gh_planner/docs_strategy.json."""
+        return _do_save_docs_strategy(strategy, referred_docs)
+
+    @mcp.tool()
+    def load_docs_strategy() -> dict:
+        """Load the saved existing-docs strategy for this project (#84).
+        Returns {strategy, referred_docs} or {strategy: null} if not set."""
+        return _do_load_docs_strategy()
 
     # ── Analyzer tool ─────────────────────────────────────────────────────────
 

--- a/extensions/github_planner/commands/github-planner.md
+++ b/extensions/github_planner/commands/github-planner.md
@@ -25,8 +25,20 @@ Ask:
 > a) GitHub URL or `owner/repo`  b) Use configured repo  c) Brand-new repo
 
 - **(b)**: read env, skip to Step 3
-- **(c)**: ask name/language/description → skip analysis → Step 5 (no doc lookup)
+- **(c)**: brand-new repo → follow **New-repo path** below
 - **(a)**: call `setup_workspace(github_repo=...)` if not already set
+
+### New-repo path (#83)
+
+When the user selects (c) or `get_session_header` returns `{docs: false}` and GitHub history is empty:
+
+1. Engage conversationally: "Tell me about your project — what is it, what's the main tech stack, and what are you building first?"
+2. From conversation: draft a minimal `project_summary.md` stub (no code analysis needed).
+   Show it: "I'll save this as your project description. Confirm? (yes / edit / cancel)"
+3. On confirm: call `update_project_description(content=...)`.
+4. Ask: "Want me to break your first features into issues? (yes / describe features first)"
+5. On yes: continue to Step 5 (planning conversation) — skip analysis entirely.
+6. Issue creation uses standard Step 6 flow with confirmation hook (#82).
 
 ---
 

--- a/extensions/github_planner/commands/github-planner/analyze.md
+++ b/extensions/github_planner/commands/github-planner/analyze.md
@@ -8,10 +8,27 @@ Repo analysis workflow:
 2. Call `docs_exist`. If summary < 7 days old, ask: "Project notes exist ({N:.0f}h old). Re-analyze? (yes / use existing)"
 3. If analyzing:
    a. Call `analyze_repo_full()` → announce: "Found {total_files} files, fetched {fetched} ({skipped_unchanged} unchanged)."
-   b. From the returned `file_index`, generate two documents using the formats below.
+   b. **Existing docs detection** (#84): from `file_index`, identify doc-like .md files
+      (paths matching: README*, docs/*, DESIGN*, ARCHITECTURE*, SPEC*, CONTRIBUTING*, CHANGELOG*).
+      If any found, present them:
+      ```
+      Found existing documentation:
+        - README.md (1.2KB)
+        - docs/DESIGN.md (3.4KB)
+      How should I handle these?
+      a) Refer to them — read and incorporate their content
+      b) Overwrite — replace with TH-generated project_summary + project_detail
+      c) Merge — combine existing + analysis into new TH docs
+      d) Ignore — create TH docs independently
+      ```
+      Save the strategy to `hub_agents/extensions/gh_planner/docs_strategy.json`:
+      `{"strategy": "refer|overwrite|merge|ignore", "referred_docs": [...]}`
+      If strategy is **refer**: note the paths; Claude reads them before generating TH docs.
+      If strategy is **ignore** or no docs found: proceed directly to step (c).
+   c. From the returned `file_index`, generate two documents using the formats below.
       Use `file_index[].exports`, `file_index[].headings`, `file_index[].module_doc` to derive
       content — never request raw file contents. Group files by feature area.
-   c. Call `save_project_docs(summary_md, detail_md)`.
+   d. Call `save_project_docs(summary_md, detail_md)`.
 4. Say: "Analysis complete. Let me know any plans for this!"
 
 ---

--- a/tests/test_repo_analysis.py
+++ b/tests/test_repo_analysis.py
@@ -761,6 +761,84 @@ def test_list_issues_submitted_has_no_local_only(workspace):
     assert "local_only" not in result["issues"][0]
 
 
+# ── detect_existing_docs + save/load_docs_strategy (#84) ──────────────────────
+
+def test_detect_existing_docs_finds_readme(workspace):
+    from extensions.github_planner import detect_existing_docs
+    file_index = [
+        {"path": "README.md", "size": 1200},
+        {"path": "src/main.py", "size": 500},
+        {"path": "docs/DESIGN.md", "size": 3400},
+        {"path": "src/utils.py", "size": 200},
+    ]
+    result = detect_existing_docs(file_index)
+    paths = [r["path"] for r in result]
+    assert "README.md" in paths
+    assert "docs/DESIGN.md" in paths
+    assert "src/main.py" not in paths
+    assert "src/utils.py" not in paths
+
+
+def test_detect_existing_docs_ignores_code_files(workspace):
+    from extensions.github_planner import detect_existing_docs
+    file_index = [
+        {"path": "src/helper.md", "size": 100},  # not doc-like
+        {"path": "CONTRIBUTING.md", "size": 500},
+    ]
+    result = detect_existing_docs(file_index)
+    paths = [r["path"] for r in result]
+    assert "CONTRIBUTING.md" in paths
+
+
+def test_save_docs_strategy_creates_file(workspace):
+    from extensions.github_planner import _do_save_docs_strategy
+    (workspace / "hub_agents").mkdir(parents=True, exist_ok=True)
+
+    with patch("extensions.github_planner.get_workspace_root", return_value=workspace):
+        result = _do_save_docs_strategy("refer", ["README.md", "docs/DESIGN.md"])
+
+    assert result["saved"] is True
+    assert result["strategy"] == "refer"
+    strategy_path = workspace / "hub_agents" / "extensions" / "gh_planner" / "docs_strategy.json"
+    assert strategy_path.exists()
+    import json
+    data = json.loads(strategy_path.read_text())
+    assert data["strategy"] == "refer"
+    assert "README.md" in data["referred_docs"]
+
+
+def test_load_docs_strategy_returns_none_when_absent(workspace):
+    from extensions.github_planner import _do_load_docs_strategy
+    (workspace / "hub_agents").mkdir(parents=True, exist_ok=True)
+
+    with patch("extensions.github_planner.get_workspace_root", return_value=workspace):
+        result = _do_load_docs_strategy()
+
+    assert result["strategy"] is None
+    assert result["referred_docs"] == []
+
+
+def test_save_docs_strategy_invalid_strategy(workspace):
+    from extensions.github_planner import _do_save_docs_strategy
+    (workspace / "hub_agents").mkdir(parents=True, exist_ok=True)
+
+    with patch("extensions.github_planner.get_workspace_root", return_value=workspace):
+        result = _do_save_docs_strategy("invalid_strategy")
+
+    assert result["error"] == "invalid_strategy"
+
+
+def test_load_docs_strategy_roundtrip(workspace):
+    from extensions.github_planner import _do_save_docs_strategy, _do_load_docs_strategy
+    (workspace / "hub_agents").mkdir(parents=True, exist_ok=True)
+
+    with patch("extensions.github_planner.get_workspace_root", return_value=workspace):
+        _do_save_docs_strategy("merge")
+        result = _do_load_docs_strategy()
+
+    assert result["strategy"] == "merge"
+
+
 # ── _do_update_project_detail_section (#65) ───────────────────────────────────
 
 def test_update_project_detail_section_creates_file(workspace):


### PR DESCRIPTION
## Summary
- **#83** `github-planner.md` detects new-repo state (via `get_session_header().docs == false`) and follows conversational project summary creation path — no code analysis needed, skip to planning conversation
- **#84** `detect_existing_docs(file_index)` identifies doc-like `.md` files; `save_docs_strategy` / `load_docs_strategy` MCP tools persist and reload user's chosen strategy (refer/overwrite/merge/ignore); `analyze.md` step 3b presents options before writing TH docs

## Test plan
- [ ] 591 tests passing, 95.36% coverage
- [ ] 6 new tests: detect_existing_docs, save/load strategy, roundtrip, invalid strategy

🤖 Generated with [Claude Code](https://claude.com/claude-code)