### PR TITLE
feat: analyze_github_labels and load_github_local_config (#81)

### DIFF
--- a/extensions/github_planner/__init__.py
+++ b/extensions/github_planner/__init__.py
@@ -135,6 +135,18 @@ def _invalidate_repo_cache() -> None:
     _REPO_CACHE.clear()
 
 
+# Per-root label analysis cache — avoids re-fetching on every call (#81)
+# Key: str(root), Value: {active_labels, closed_labels, fetched_at}
+_LABEL_CACHE: dict[str, dict] = {}
+
+_GITHUB_DEFAULT_LABEL_NAMES = frozenset({
+    "bug", "documentation", "duplicate", "enhancement", "good first issue",
+    "help wanted", "invalid", "question", "wontfix",
+})
+
+_LABEL_ACTIVE_DAYS = 30  # labels created within this many days are considered "active"
+
+
 # ── Internal alias for analyzer ───────────────────────────────────────────────
 _get_github_client = get_github_client
 
@@ -1382,6 +1394,153 @@ def _do_load_docs_strategy() -> dict:
         return {"strategy": None, "referred_docs": []}
 
 
+# ── Label analysis (#81) ──────────────────────────────────────────────────────
+
+def _do_analyze_github_labels(refresh: bool = False) -> dict:
+    """Fetch labels from GitHub, classify active vs closed, save to github_local_config.json (#81).
+
+    active_labels: labels with open issues or created < 30 days ago.
+    closed_labels: labels with no open issues and created > 30 days ago.
+
+    On first call for a new repo with only GitHub defaults, suggests project-specific labels.
+    """
+    root = get_workspace_root()
+    if err := ensure_initialized(root):
+        return err
+
+    root_key = str(root)
+    if not refresh and root_key in _LABEL_CACHE:
+        cached = _LABEL_CACHE[root_key]
+        return {**cached, "cached": True}
+
+    gh, error_message = get_github_client()
+    if gh is None:
+        return {"error": "github_unavailable", "message": error_message, "_guidance": _G_AUTH}
+
+    with gh:
+        try:
+            raw_labels = gh.list_labels()
+            open_issues = gh.list_issues(state="open", per_page=100)
+        except Exception as exc:
+            return {"error": "github_error", "message": str(exc)}
+
+    # Build set of label names that have open issues
+    labels_with_open_issues: set[str] = set()
+    for issue in open_issues:
+        for lbl in issue.get("labels", []):
+            labels_with_open_issues.add(lbl.get("name", ""))
+
+    now_ts = time.time()
+    active_labels: list[dict] = []
+    closed_labels: list[dict] = []
+
+    for lbl in raw_labels:
+        name = lbl.get("name", "")
+        created_at_str = lbl.get("created_at", "")
+        has_open = name in labels_with_open_issues
+
+        # Parse created_at to determine age
+        age_days: float | None = None
+        if created_at_str:
+            try:
+                import datetime as _dt
+                created_ts = _dt.datetime.fromisoformat(
+                    created_at_str.replace("Z", "+00:00")
+                ).timestamp()
+                age_days = (now_ts - created_ts) / 86400
+            except (ValueError, OSError):
+                age_days = None
+
+        is_recent = age_days is not None and age_days < _LABEL_ACTIVE_DAYS
+
+        entry = {
+            "name": name,
+            "color": lbl.get("color", ""),
+            "description": lbl.get("description", ""),
+        }
+        if has_open or is_recent:
+            active_labels.append(entry)
+        else:
+            closed_labels.append(entry)
+
+    # Check if only GitHub default labels exist (new repo path)
+    all_names = {lbl.get("name", "") for lbl in raw_labels}
+    only_defaults = bool(raw_labels) and all_names.issubset(_GITHUB_DEFAULT_LABEL_NAMES)
+
+    result: dict = {
+        "active_labels": active_labels,
+        "closed_labels": closed_labels,
+        "total": len(raw_labels),
+        "only_defaults": only_defaults,
+    }
+
+    # Save to disk
+    docs_dir = _gh_planner_docs_dir(root)
+    docs_dir.mkdir(parents=True, exist_ok=True)
+    config_path = docs_dir / "github_local_config.json"
+
+    existing: dict = {}
+    if config_path.exists():
+        try:
+            existing = json.loads(config_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            existing = {}
+
+    existing["labels"] = {
+        "active": active_labels,
+        "closed": closed_labels,
+        "fetched_at": now_ts,
+    }
+    tmp = config_path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(existing, indent=2), encoding="utf-8")
+    import os as _os5; _os5.replace(tmp, config_path)
+
+    # Update in-memory cache
+    _LABEL_CACHE[root_key] = {
+        "active_labels": active_labels,
+        "closed_labels": closed_labels,
+        "total": len(raw_labels),
+        "only_defaults": only_defaults,
+    }
+
+    n_active = len(active_labels)
+    n_closed = len(closed_labels)
+    result["_display"] = (
+        f"✓ Labels analyzed: {n_active} active, {n_closed} inactive\n"
+        f"  Saved to hub_agents/extensions/gh_planner/github_local_config.json"
+    )
+    if only_defaults:
+        result["suggestion"] = (
+            "Only GitHub default labels found. Consider adding project-specific labels "
+            "based on your feature areas. Call analyze_github_labels again after creating them."
+        )
+    return result
+
+
+def _do_load_github_local_config() -> dict:
+    """Load github_local_config.json from disk, or return empty config (#81)."""
+    root = get_workspace_root()
+    if err := ensure_initialized(root):
+        return err
+
+    config_path = _gh_planner_docs_dir(root) / "github_local_config.json"
+    if not config_path.exists():
+        return {"labels": None, "fetched_at": None}
+
+    try:
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+        labels_section = data.get("labels", {})
+        return {
+            "labels": {
+                "active": labels_section.get("active", []),
+                "closed": labels_section.get("closed", []),
+            },
+            "fetched_at": labels_section.get("fetched_at"),
+        }
+    except (json.JSONDecodeError, OSError):
+        return {"labels": None, "fetched_at": None}
+
+
 # ── Plugin unload ─────────────────────────────────────────────────────────────
 
 # All volatile cache files owned by gh_planner (project docs and issues are NOT included)
@@ -1389,6 +1548,7 @@ _GH_PLANNER_VOLATILE_FILES = [
     "analyzer_snapshot.json",
     "file_hashes.json",
     "file_tree.json",
+    "github_local_config.json",
 ]
 
 
@@ -1409,6 +1569,8 @@ def _do_list_plugin_state(plugin: str) -> dict:
         caches.append({"name": "_FILE_TREE_CACHE", "fetched_at": _FILE_TREE_CACHE.get("fetched_at")})
     if _SESSION_HEADER_CACHE:
         caches.append({"name": "_SESSION_HEADER_CACHE", "entries": len(_SESSION_HEADER_CACHE)})
+    if _LABEL_CACHE:
+        caches.append({"name": "_LABEL_CACHE", "entries": len(_LABEL_CACHE)})
 
     disk_files = []
     for fname in _GH_PLANNER_VOLATILE_FILES:
@@ -1429,6 +1591,7 @@ def _do_list_plugin_state(plugin: str) -> dict:
         + _dict_size_kb(_PROJECT_DOCS_CACHE)
         + _dict_size_kb(_FILE_TREE_CACHE)
         + _dict_size_kb(_SESSION_HEADER_CACHE)
+        + _dict_size_kb(_LABEL_CACHE)
     )
     _SUGGEST_UNLOAD_KB = 500
 
@@ -1468,6 +1631,7 @@ def _do_unload_plugin(plugin: str) -> dict:
         (_PROJECT_DOCS_CACHE, "_PROJECT_DOCS_CACHE"),
         (_FILE_TREE_CACHE, "_FILE_TREE_CACHE"),
         (_SESSION_HEADER_CACHE, "_SESSION_HEADER_CACHE"),
+        (_LABEL_CACHE, "_LABEL_CACHE"),
     ]:
         if cache:
             cache.clear()
@@ -1779,3 +1943,28 @@ def register(mcp) -> None:
         On error returns {success: false, errors: [...]} — analyze errors and retry.
         """
         return _do_unload_plugin(plugin)
+
+    @mcp.tool()
+    def analyze_github_labels(refresh: bool = False) -> dict:
+        """Fetch and classify GitHub labels for the configured repo (#81).
+
+        Classifies labels as:
+          active_labels  — labels with open issues OR created < 30 days ago
+          closed_labels  — labels with no open issues AND created > 30 days ago
+
+        Results saved to hub_agents/extensions/gh_planner/github_local_config.json.
+        Use active_labels when suggesting labels for new issues via draft_issue.
+
+        If only GitHub default labels exist, returns suggestion for project-specific labels.
+        Set refresh=True to bypass the in-memory cache and re-fetch from GitHub.
+        """
+        return _do_analyze_github_labels(refresh)
+
+    @mcp.tool()
+    def load_github_local_config() -> dict:
+        """Read the saved github_local_config.json from disk (#81).
+
+        Returns {labels: {active: [...], closed: [...]}, fetched_at: float | null}.
+        Call analyze_github_labels first to populate this file.
+        """
+        return _do_load_github_local_config()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import pytest
 from extensions.github_planner import (
     _ANALYSIS_CACHE,
     _FILE_TREE_CACHE,
+    _LABEL_CACHE,
     _PROJECT_DOCS_CACHE,
     _REPO_CACHE,
     _SESSION_HEADER_CACHE,
@@ -19,6 +20,7 @@ def clear_all_caches():
     _PROJECT_DOCS_CACHE.clear()
     _FILE_TREE_CACHE.clear()
     _SESSION_HEADER_CACHE.clear()
+    _LABEL_CACHE.clear()
     _invalidate_repo_cache()
     invalidate_token_cache()
     yield
@@ -26,5 +28,6 @@ def clear_all_caches():
     _PROJECT_DOCS_CACHE.clear()
     _FILE_TREE_CACHE.clear()
     _SESSION_HEADER_CACHE.clear()
+    _LABEL_CACHE.clear()
     _invalidate_repo_cache()
     invalidate_token_cache()

--- a/tests/test_repo_analysis.py
+++ b/tests/test_repo_analysis.py
@@ -1180,3 +1180,181 @@ def test_get_session_header_no_truncation_when_few_sections(workspace):
         result = _do_get_session_header()
     assert len(result["sections"]) == 2
     assert "sections_truncated" not in result
+
+
+# ── _do_analyze_github_labels / _do_load_github_local_config (#81) ────────────
+
+def _make_mock_gh(labels=None, open_issues=None):
+    """Helper to build a mock GitHubClient for label tests."""
+    mock = MagicMock()
+    mock.__enter__ = lambda s: s
+    mock.__exit__ = MagicMock(return_value=False)
+    mock.list_labels.return_value = labels or []
+    mock.list_issues.return_value = open_issues or []
+    return mock
+
+
+def test_analyze_github_labels_active_if_has_open_issues(workspace):
+    from extensions.github_planner import _do_analyze_github_labels
+    (workspace / "hub_agents").mkdir(parents=True, exist_ok=True)
+
+    # Label "bug" has an open issue
+    labels = [{"name": "bug", "color": "ee0701", "description": "A bug", "created_at": "2020-01-01T00:00:00Z"}]
+    open_issues = [{"labels": [{"name": "bug"}]}]
+    mock_gh = _make_mock_gh(labels=labels, open_issues=open_issues)
+
+    with patch("extensions.github_planner.get_workspace_root", return_value=workspace), \
+         patch("extensions.github_planner.get_github_client", return_value=(mock_gh, "")):
+        result = _do_analyze_github_labels()
+
+    assert result.get("error") is None
+    assert any(l["name"] == "bug" for l in result["active_labels"])
+    assert result["closed_labels"] == []
+
+
+def test_analyze_github_labels_closed_if_old_and_no_open_issues(workspace):
+    from extensions.github_planner import _do_analyze_github_labels
+    (workspace / "hub_agents").mkdir(parents=True, exist_ok=True)
+
+    # Label created 60 days ago, no open issues
+    old_ts = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(time.time() - 60 * 86400))
+    labels = [{"name": "stale", "color": "aaaaaa", "description": "", "created_at": old_ts}]
+
+    mock_gh = _make_mock_gh(labels=labels, open_issues=[])
+
+    with patch("extensions.github_planner.get_workspace_root", return_value=workspace), \
+         patch("extensions.github_planner.get_github_client", return_value=(mock_gh, "")):
+        result = _do_analyze_github_labels()
+
+    assert result.get("error") is None
+    assert result["active_labels"] == []
+    assert any(l["name"] == "stale" for l in result["closed_labels"])
+
+
+def test_analyze_github_labels_active_if_recently_created(workspace):
+    from extensions.github_planner import _do_analyze_github_labels
+    (workspace / "hub_agents").mkdir(parents=True, exist_ok=True)
+
+    # Label created 5 days ago (recent), no open issues
+    recent_ts = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(time.time() - 5 * 86400))
+    labels = [{"name": "new-feature", "color": "0075ca", "description": "", "created_at": recent_ts}]
+
+    mock_gh = _make_mock_gh(labels=labels, open_issues=[])
+
+    with patch("extensions.github_planner.get_workspace_root", return_value=workspace), \
+         patch("extensions.github_planner.get_github_client", return_value=(mock_gh, "")):
+        result = _do_analyze_github_labels()
+
+    assert result.get("error") is None
+    assert any(l["name"] == "new-feature" for l in result["active_labels"])
+    assert result["closed_labels"] == []
+
+
+def test_analyze_github_labels_saves_to_disk(workspace):
+    from extensions.github_planner import _do_analyze_github_labels
+    (workspace / "hub_agents").mkdir(parents=True, exist_ok=True)
+
+    labels = [{"name": "enhancement", "color": "a2eeef", "description": "", "created_at": "2020-01-01T00:00:00Z"}]
+    open_issues = [{"labels": [{"name": "enhancement"}]}]
+    mock_gh = _make_mock_gh(labels=labels, open_issues=open_issues)
+
+    with patch("extensions.github_planner.get_workspace_root", return_value=workspace), \
+         patch("extensions.github_planner.get_github_client", return_value=(mock_gh, "")):
+        _do_analyze_github_labels()
+
+    config_path = workspace / "hub_agents" / "extensions" / "gh_planner" / "github_local_config.json"
+    assert config_path.exists()
+    data = json.loads(config_path.read_text(encoding="utf-8"))
+    assert "labels" in data
+    assert any(l["name"] == "enhancement" for l in data["labels"]["active"])
+
+
+def test_analyze_github_labels_only_defaults_flag(workspace):
+    from extensions.github_planner import _do_analyze_github_labels
+    (workspace / "hub_agents").mkdir(parents=True, exist_ok=True)
+
+    # Only GitHub default labels
+    labels = [
+        {"name": "bug", "color": "ee0701", "description": "", "created_at": "2020-01-01T00:00:00Z"},
+        {"name": "enhancement", "color": "a2eeef", "description": "", "created_at": "2020-01-01T00:00:00Z"},
+    ]
+    mock_gh = _make_mock_gh(labels=labels, open_issues=[])
+
+    with patch("extensions.github_planner.get_workspace_root", return_value=workspace), \
+         patch("extensions.github_planner.get_github_client", return_value=(mock_gh, "")):
+        result = _do_analyze_github_labels()
+
+    assert result["only_defaults"] is True
+    assert "suggestion" in result
+
+
+def test_analyze_github_labels_no_auth(workspace):
+    from extensions.github_planner import _do_analyze_github_labels
+    (workspace / "hub_agents").mkdir(parents=True, exist_ok=True)
+
+    with patch("extensions.github_planner.get_workspace_root", return_value=workspace), \
+         patch("extensions.github_planner.get_github_client", return_value=(None, "No token")):
+        result = _do_analyze_github_labels()
+
+    assert result["error"] == "github_unavailable"
+
+
+def test_analyze_github_labels_cache_hit(workspace):
+    from extensions.github_planner import _do_analyze_github_labels, _LABEL_CACHE
+    (workspace / "hub_agents").mkdir(parents=True, exist_ok=True)
+
+    labels = [{"name": "bug", "color": "ee0701", "description": "", "created_at": "2020-01-01T00:00:00Z"}]
+    mock_gh = _make_mock_gh(labels=labels, open_issues=[{"labels": [{"name": "bug"}]}])
+
+    with patch("extensions.github_planner.get_workspace_root", return_value=workspace), \
+         patch("extensions.github_planner.get_github_client", return_value=(mock_gh, "")) as mock_client:
+        _do_analyze_github_labels()
+        result2 = _do_analyze_github_labels()
+
+    # Second call should use cache — get_github_client called only once
+    assert result2.get("cached") is True
+    assert mock_client.call_count == 1
+
+
+def test_analyze_github_labels_refresh_bypasses_cache(workspace):
+    from extensions.github_planner import _do_analyze_github_labels
+    (workspace / "hub_agents").mkdir(parents=True, exist_ok=True)
+
+    labels = [{"name": "bug", "color": "ee0701", "description": "", "created_at": "2020-01-01T00:00:00Z"}]
+    mock_gh = _make_mock_gh(labels=labels, open_issues=[{"labels": [{"name": "bug"}]}])
+
+    with patch("extensions.github_planner.get_workspace_root", return_value=workspace), \
+         patch("extensions.github_planner.get_github_client", return_value=(mock_gh, "")) as mock_client:
+        _do_analyze_github_labels()
+        _do_analyze_github_labels(refresh=True)
+
+    # refresh=True should call GitHub again
+    assert mock_client.call_count == 2
+
+
+def test_load_github_local_config_absent(workspace):
+    from extensions.github_planner import _do_load_github_local_config
+    (workspace / "hub_agents").mkdir(parents=True, exist_ok=True)
+
+    with patch("extensions.github_planner.get_workspace_root", return_value=workspace):
+        result = _do_load_github_local_config()
+
+    assert result["labels"] is None
+    assert result["fetched_at"] is None
+
+
+def test_load_github_local_config_roundtrip(workspace):
+    from extensions.github_planner import _do_analyze_github_labels, _do_load_github_local_config
+    (workspace / "hub_agents").mkdir(parents=True, exist_ok=True)
+
+    labels = [{"name": "bug", "color": "ee0701", "description": "", "created_at": "2020-01-01T00:00:00Z"}]
+    mock_gh = _make_mock_gh(labels=labels, open_issues=[{"labels": [{"name": "bug"}]}])
+
+    with patch("extensions.github_planner.get_workspace_root", return_value=workspace), \
+         patch("extensions.github_planner.get_github_client", return_value=(mock_gh, "")):
+        _do_analyze_github_labels()
+        result = _do_load_github_local_config()
+
+    assert result["labels"] is not None
+    assert any(l["name"] == "bug" for l in result["labels"]["active"])
+    assert result["fetched_at"] is not None


### PR DESCRIPTION
## Summary

- Adds `analyze_github_labels(refresh=False)` MCP tool: fetches labels from GitHub API, classifies into `active_labels` (open issues or created < 30 days) and `closed_labels` (no open issues and older), saves to `hub_agents/extensions/gh_planner/github_local_config.json`
- Adds `load_github_local_config()` MCP tool: reads saved label config from disk
- `_LABEL_CACHE` dict keyed by workspace root for in-memory caching (respects `refresh=True`)
- Flags `only_defaults=True` + `suggestion` when repo only has GitHub built-in labels (new repo path)
- `github_local_config.json` added to `_GH_PLANNER_VOLATILE_FILES` — cleared on `unload_plugin`
- `_LABEL_CACHE` tracked in `list_plugin_state` and cleared in `unload_plugin`

## Test plan

- [x] 10 new tests: active/closed classification, recently-created label, disk persistence, only-defaults flag, no-auth graceful failure, cache hit, refresh bypass, absent config, round-trip load
- [x] 601 tests passing, 94.92% coverage

Closes #81