### PR TITLE
feat: sync_github_issues — Python-fetched GitHub issue cache (#113)

### DIFF
--- a/extensions/builtin/active.md
+++ b/extensions/builtin/active.md
@@ -27,6 +27,17 @@ On no: skip to next item.
 If `runtime.load_warnings` is non-empty, highlight each warning with ⚠ and suggest
 the user check their plugin manifests.
 
+## Unload suggestion
+
+After displaying state, call `list_issues(compact=True)`.
+If the response contains `_suggest_unload`, display it as a prompt:
+
+  "💡 [unload suggestion text]"
+
+Then ask: "Would you like me to unload the GitHub issue manager to free up context?
+  **yes** — call `unload_plugin('gh_planner')` and confirm
+  **no**  — continue working"
+
 ## After all items
 
 Say: "Active state complete. Run /github_planner:analyze to refresh the snapshot,

--- a/extensions/github_planner/__init__.py
+++ b/extensions/github_planner/__init__.py
@@ -1306,7 +1306,17 @@ def _do_list_issues(compact: bool = False) -> dict:
         issues = [{"slug": i["slug"], "title": i["title"], "status": i["status"],
                    **({"local_only": True} if i.get("local_only") else {})}
                   for i in issues]
-    return {"issues": issues}
+    result: dict = {"issues": issues}
+    # Hint to sync if cache is stale (#113)
+    if _issues_cache_stale(root):
+        result["_suggest_sync"] = (
+            "Issue cache is empty or stale. Call sync_github_issues() to fetch "
+            "the latest issues from GitHub at ~30 tokens/issue instead of ~150."
+        )
+    # Unload suggestion when session caches are heavy (#113)
+    if hint := _check_suggest_unload():
+        result["_suggest_unload"] = hint
+    return result
 
 
 def _do_list_pending_drafts() -> dict:
@@ -1322,6 +1332,165 @@ def _do_list_pending_drafts() -> dict:
         if not i.get("issue_number")
     ]
     return {"pending_drafts": pending, "count": len(pending)}
+
+
+# ── GitHub issues sync (#113) ─────────────────────────────────────────────────
+
+_ISSUES_SYNC_TTL = 3600  # seconds — cache considered stale after 1 hour
+
+
+def _check_suggest_unload() -> str | None:
+    """Return an unload suggestion string when session caches are heavy.
+
+    Triggered when analysis, project docs, AND label caches are all populated.
+    """
+    if _ANALYSIS_CACHE and _PROJECT_DOCS_CACHE and _LABEL_CACHE:
+        return (
+            "Context is getting heavy. Say 'unload github issue manager' to free memory "
+            "and keep things fast, or continue working."
+        )
+    return None
+
+
+def _do_sync_github_issues(state: str = "open", refresh: bool = False) -> dict:
+    """Fetch issues from GitHub API and write to hub_agents/issues/ as local .md files (#113).
+
+    Uses Python to fetch all issues (paginated), skipping unchanged ones.
+    Records issues_synced_at in github_local_config.json.
+
+    Returns {synced, skipped, total, _display}.
+    """
+    root = get_workspace_root()
+    if err := ensure_initialized(root):
+        return err
+
+    valid_states = {"open", "closed", "all"}
+    if state not in valid_states:
+        return {"error": "invalid_state", "message": f"state must be one of {sorted(valid_states)}"}
+
+    gh, error_message = get_github_client()
+    if gh is None:
+        return {"error": "github_unavailable", "message": error_message, "_guidance": _G_AUTH}
+
+    with gh:
+        try:
+            raw_issues = gh.list_issues_all(state=state)
+        except Exception as exc:
+            return {"error": "github_error", "message": str(exc)}
+
+    issues_dir = root / "hub_agents" / "issues"
+    issues_dir.mkdir(parents=True, exist_ok=True)
+
+    # Build lookup of existing local files by issue_number for skip check
+    existing_by_number: dict[int, dict] = {}
+    for existing in list_issue_files(root):
+        num = existing.get("issue_number")
+        if num:
+            existing_by_number[num] = existing
+
+    synced = 0
+    skipped = 0
+
+    for raw in raw_issues:
+        # Skip pull requests (GitHub returns PRs in issues endpoint)
+        if raw.get("pull_request"):
+            continue
+
+        number = raw.get("number")
+        title = raw.get("title", "")
+        body = raw.get("body") or ""
+        issue_state = raw.get("state", "open")
+        labels = [l["name"] for l in raw.get("labels", [])]
+        assignees = [a["login"] for a in raw.get("assignees", [])]
+        created_at_str = raw.get("created_at", "")
+        updated_at_str = raw.get("updated_at", "")
+        github_url = raw.get("html_url", "")
+
+        # Build slug: {number}-{slugified-title}
+        base_slug = f"{number}-{slugify(title)}" if number else slugify(title)
+        if not base_slug:
+            base_slug = str(number or "unknown")
+
+        # Skip if already exists and not refreshing and not changed
+        if not refresh and number in existing_by_number:
+            existing = existing_by_number[number]
+            # Read existing file to check updated_at
+            existing_path = issues_dir / f"{existing['slug']}.md"
+            if existing_path.exists():
+                content = existing_path.read_text(encoding="utf-8")
+                if updated_at_str and updated_at_str in content:
+                    skipped += 1
+                    continue
+
+        # Map GitHub state to IssueStatus
+        issue_status = IssueStatus.OPEN if issue_state == "open" else IssueStatus.CLOSED
+
+        # Parse created_at date
+        try:
+            import datetime as _dt
+            created_date = _dt.datetime.fromisoformat(
+                created_at_str.replace("Z", "+00:00")
+            ).date()
+        except (ValueError, AttributeError):
+            created_date = date.today()
+
+        # Build body with metadata footer
+        body_with_meta = body
+        if updated_at_str:
+            body_with_meta = f"{body}\n\n<!-- synced_at: {updated_at_str} -->"
+
+        # Use fixed slug: number-title to avoid collisions with re-syncs
+        slug = base_slug
+        # If a different slug exists for this number, reuse it
+        if number in existing_by_number:
+            slug = existing_by_number[number]["slug"]
+
+        write_issue_file(
+            root=root,
+            slug=slug,
+            title=title,
+            body=body_with_meta,
+            assignees=assignees,
+            labels=labels,
+            created_at=created_date,
+            status=issue_status,
+            issue_number=number,
+            github_url=github_url,
+        )
+        synced += 1
+
+    # Record sync timestamp in github_local_config.json
+    _do_save_github_local_config({"issues_synced_at": time.time(), "issues_state": state})
+
+    total = len(raw_issues)
+    env = read_env(root)
+    repo = env.get("GITHUB_REPO", "unknown")
+    return {
+        "synced": synced,
+        "skipped": skipped,
+        "total": total,
+        "state": state,
+        "_display": (
+            f"✓ Synced {synced} issue(s) from {repo} ({state})\n"
+            f"  Skipped {skipped} unchanged | Total fetched: {total}\n"
+            f"  Stored in hub_agents/issues/"
+        ),
+    }
+
+
+def _issues_cache_stale(root: Path) -> bool:
+    """Return True if local issue cache is empty or older than _ISSUES_SYNC_TTL."""
+    config_path = _local_config_path(root)
+    if not config_path.exists():
+        return True
+    try:
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+        synced_at = data.get("issues_synced_at")
+        if not synced_at:
+            return True
+        return (time.time() - float(synced_at)) > _ISSUES_SYNC_TTL
+    except (json.JSONDecodeError, OSError, ValueError):
+        return True
 
 
 # ── Existing docs detection (#84) ─────────────────────────────────────────────
@@ -1851,8 +2020,24 @@ def register(mcp) -> None:
         """Return tracked issues from local hub_agents/issues/ files.
         compact=True: returns [{slug, title, status}] only (~3× fewer tokens).
         compact=False (default): returns full issue metadata.
-        Issues never submitted to GitHub are marked with local_only: true (#102)."""
+        Issues never submitted to GitHub are marked with local_only: true (#102).
+        If cache is stale, _suggest_sync hints to call sync_github_issues() first (#113)."""
         return _do_list_issues(compact)
+
+    @mcp.tool()
+    def sync_github_issues(state: str = "open", refresh: bool = False) -> dict:
+        """Fetch GitHub issues and cache them locally as .md files (#113).
+
+        Python fetches all issues (paginated) and writes to hub_agents/issues/.
+        ~30 tokens/issue vs ~150 tokens if Claude were to relay raw API responses.
+
+        state: 'open' (default), 'closed', or 'all'
+        refresh: True to re-fetch all issues even if unchanged (default: skip unchanged)
+
+        Returns {synced, skipped, total, _display}.
+        After syncing, call list_issues() to read the cached results.
+        """
+        return _do_sync_github_issues(state, refresh)
 
     @mcp.tool()
     def list_pending_drafts() -> dict:

--- a/extensions/github_planner/client.py
+++ b/extensions/github_planner/client.py
@@ -145,6 +145,26 @@ class GitHubClient:
         resp.raise_for_status()
         return resp.json()
 
+    def list_issues_all(self, state: str = "open") -> list[dict]:
+        """List all issues with pagination (up to 500)."""
+        _, url = self._url("github", "list_issues")
+        issues: list[dict] = []
+        page = 1
+        while len(issues) < 500:
+            try:
+                resp = self._client.get(url, params={"state": state, "per_page": 100, "page": page})
+                resp.raise_for_status()
+            except Exception:
+                break
+            data = resp.json()
+            if not data:
+                break
+            issues.extend(data)
+            if len(data) < 100:
+                break
+            page += 1
+        return issues
+
     def list_collaborators(self) -> list[dict]:
         """List repo collaborators."""
         url = BASE_URL + f"/repos/{self.repo}/collaborators"

--- a/tests/test_repo_analysis.py
+++ b/tests/test_repo_analysis.py
@@ -1481,3 +1481,205 @@ def test_global_config_not_in_volatile_files():
 def test_local_config_in_volatile_files():
     from extensions.github_planner import _GH_PLANNER_VOLATILE_FILES
     assert "github_local_config.json" in _GH_PLANNER_VOLATILE_FILES
+
+
+# ── sync_github_issues / _check_suggest_unload (#113) ─────────────────────────
+
+def _make_raw_issue(number=1, title="Fix bug", state="open", updated_at=None, labels=None, is_pr=False):
+    raw = {
+        "number": number,
+        "title": title,
+        "body": "Issue body.",
+        "state": state,
+        "labels": [{"name": l} for l in (labels or [])],
+        "assignees": [],
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": updated_at or "2026-01-02T00:00:00Z",
+        "html_url": f"https://github.com/owner/repo/issues/{number}",
+    }
+    if is_pr:
+        raw["pull_request"] = {"url": "..."}
+    return raw
+
+
+def test_sync_github_issues_writes_local_files(workspace):
+    from extensions.github_planner import _do_sync_github_issues
+    (workspace / "hub_agents").mkdir(parents=True, exist_ok=True)
+
+    mock_gh = MagicMock()
+    mock_gh.__enter__ = lambda s: s
+    mock_gh.__exit__ = MagicMock(return_value=False)
+    mock_gh.list_issues_all.return_value = [
+        _make_raw_issue(1, "Fix auth bug"),
+        _make_raw_issue(2, "Add dark mode"),
+    ]
+
+    with patch("extensions.github_planner.get_workspace_root", return_value=workspace), \
+         patch("extensions.github_planner.get_github_client", return_value=(mock_gh, "")), \
+         patch("extensions.github_planner.read_env", return_value={"GITHUB_REPO": "owner/repo"}):
+        result = _do_sync_github_issues()
+
+    assert result.get("error") is None
+    assert result["synced"] == 2
+    issues_dir = workspace / "hub_agents" / "issues"
+    assert issues_dir.exists()
+    assert len(list(issues_dir.glob("*.md"))) == 2
+
+
+def test_sync_github_issues_skips_pull_requests(workspace):
+    from extensions.github_planner import _do_sync_github_issues
+    (workspace / "hub_agents").mkdir(parents=True, exist_ok=True)
+
+    mock_gh = MagicMock()
+    mock_gh.__enter__ = lambda s: s
+    mock_gh.__exit__ = MagicMock(return_value=False)
+    mock_gh.list_issues_all.return_value = [
+        _make_raw_issue(1, "Real issue"),
+        _make_raw_issue(2, "A PR", is_pr=True),
+    ]
+
+    with patch("extensions.github_planner.get_workspace_root", return_value=workspace), \
+         patch("extensions.github_planner.get_github_client", return_value=(mock_gh, "")), \
+         patch("extensions.github_planner.read_env", return_value={"GITHUB_REPO": "owner/repo"}):
+        result = _do_sync_github_issues()
+
+    assert result["synced"] == 1
+    assert result["total"] == 2  # total includes the PR in raw count
+
+
+def test_sync_github_issues_skips_unchanged(workspace):
+    from extensions.github_planner import _do_sync_github_issues
+    (workspace / "hub_agents").mkdir(parents=True, exist_ok=True)
+
+    updated_at = "2026-01-02T00:00:00Z"
+    raw = _make_raw_issue(1, "Fix bug", updated_at=updated_at)
+    mock_gh = MagicMock()
+    mock_gh.__enter__ = lambda s: s
+    mock_gh.__exit__ = MagicMock(return_value=False)
+    mock_gh.list_issues_all.return_value = [raw]
+
+    with patch("extensions.github_planner.get_workspace_root", return_value=workspace), \
+         patch("extensions.github_planner.get_github_client", return_value=(mock_gh, "")), \
+         patch("extensions.github_planner.read_env", return_value={"GITHUB_REPO": "owner/repo"}):
+        # First sync writes the file
+        _do_sync_github_issues()
+        # Second sync should skip unchanged
+        result = _do_sync_github_issues()
+
+    assert result["skipped"] == 1
+    assert result["synced"] == 0
+
+
+def test_sync_github_issues_refresh_forces_rewrite(workspace):
+    from extensions.github_planner import _do_sync_github_issues
+    (workspace / "hub_agents").mkdir(parents=True, exist_ok=True)
+
+    raw = _make_raw_issue(1, "Fix bug", updated_at="2026-01-02T00:00:00Z")
+    mock_gh = MagicMock()
+    mock_gh.__enter__ = lambda s: s
+    mock_gh.__exit__ = MagicMock(return_value=False)
+    mock_gh.list_issues_all.return_value = [raw]
+
+    with patch("extensions.github_planner.get_workspace_root", return_value=workspace), \
+         patch("extensions.github_planner.get_github_client", return_value=(mock_gh, "")), \
+         patch("extensions.github_planner.read_env", return_value={"GITHUB_REPO": "owner/repo"}):
+        _do_sync_github_issues()
+        result = _do_sync_github_issues(refresh=True)
+
+    assert result["synced"] == 1
+    assert result["skipped"] == 0
+
+
+def test_sync_github_issues_invalid_state(workspace):
+    from extensions.github_planner import _do_sync_github_issues
+    (workspace / "hub_agents").mkdir(parents=True, exist_ok=True)
+
+    with patch("extensions.github_planner.get_workspace_root", return_value=workspace):
+        result = _do_sync_github_issues(state="unknown")
+
+    assert result["error"] == "invalid_state"
+
+
+def test_sync_github_issues_no_auth(workspace):
+    from extensions.github_planner import _do_sync_github_issues
+    (workspace / "hub_agents").mkdir(parents=True, exist_ok=True)
+
+    with patch("extensions.github_planner.get_workspace_root", return_value=workspace), \
+         patch("extensions.github_planner.get_github_client", return_value=(None, "No token")):
+        result = _do_sync_github_issues()
+
+    assert result["error"] == "github_unavailable"
+
+
+def test_sync_github_issues_records_synced_at(workspace):
+    from extensions.github_planner import _do_sync_github_issues
+    (workspace / "hub_agents").mkdir(parents=True, exist_ok=True)
+
+    mock_gh = MagicMock()
+    mock_gh.__enter__ = lambda s: s
+    mock_gh.__exit__ = MagicMock(return_value=False)
+    mock_gh.list_issues_all.return_value = [_make_raw_issue(1, "Test")]
+
+    with patch("extensions.github_planner.get_workspace_root", return_value=workspace), \
+         patch("extensions.github_planner.get_github_client", return_value=(mock_gh, "")), \
+         patch("extensions.github_planner.read_env", return_value={"GITHUB_REPO": "owner/repo"}):
+        _do_sync_github_issues()
+
+    config_path = workspace / "hub_agents" / "extensions" / "gh_planner" / "github_local_config.json"
+    assert config_path.exists()
+    data = json.loads(config_path.read_text(encoding="utf-8"))
+    assert "issues_synced_at" in data
+
+
+def test_check_suggest_unload_all_caches(workspace):
+    from extensions.github_planner import _check_suggest_unload, _ANALYSIS_CACHE, _PROJECT_DOCS_CACHE, _LABEL_CACHE
+    _ANALYSIS_CACHE["key"] = {"data": "x"}
+    _PROJECT_DOCS_CACHE["key"] = {"data": "x"}
+    _LABEL_CACHE["key"] = {"data": "x"}
+    result = _check_suggest_unload()
+    assert result is not None
+    assert "unload" in result.lower()
+
+
+def test_check_suggest_unload_partial_caches():
+    from extensions.github_planner import _check_suggest_unload, _ANALYSIS_CACHE, _PROJECT_DOCS_CACHE, _LABEL_CACHE
+    # Only analysis cache populated — should not suggest
+    _ANALYSIS_CACHE["key"] = {"data": "x"}
+    result = _check_suggest_unload()
+    assert result is None
+
+
+def test_list_issues_suggest_sync_when_stale(workspace):
+    (workspace / "hub_agents").mkdir(parents=True, exist_ok=True)
+
+    with patch("extensions.github_planner.get_workspace_root", return_value=workspace):
+        result = _do_list_issues()
+
+    # No github_local_config.json → cache is stale
+    assert "_suggest_sync" in result
+
+
+def test_list_issues_no_suggest_sync_when_fresh(workspace):
+    from extensions.github_planner import _do_save_github_local_config
+    (workspace / "hub_agents").mkdir(parents=True, exist_ok=True)
+
+    # Write a fresh synced_at timestamp
+    with patch("extensions.github_planner.get_workspace_root", return_value=workspace):
+        _do_save_github_local_config({"issues_synced_at": time.time()})
+        result = _do_list_issues()
+
+    assert "_suggest_sync" not in result
+
+
+def test_list_issues_suggest_unload_when_heavy(workspace):
+    from extensions.github_planner import _ANALYSIS_CACHE, _PROJECT_DOCS_CACHE, _LABEL_CACHE, _do_save_github_local_config
+    (workspace / "hub_agents").mkdir(parents=True, exist_ok=True)
+    _ANALYSIS_CACHE["k"] = {}
+    _PROJECT_DOCS_CACHE["k"] = {}
+    _LABEL_CACHE["k"] = {}
+
+    with patch("extensions.github_planner.get_workspace_root", return_value=workspace):
+        _do_save_github_local_config({"issues_synced_at": time.time()})
+        result = _do_list_issues()
+
+    assert "_suggest_unload" in result


### PR DESCRIPTION
## Summary

- `sync_github_issues(state='open', refresh=False)` MCP tool: fetches all GitHub issues via paginated Python API calls (not Claude relay), writes them as `.md` files to `hub_agents/issues/` at ~30 tokens/issue instead of ~150
- Skips unchanged issues by comparing `synced_at: {updated_at}` markers in file content; skips pull requests
- Records `issues_synced_at` timestamp in `github_local_config.json`
- `list_issues()` now emits `_suggest_sync` hint when cache is absent or stale (> 1 hour)
- `_check_suggest_unload()`: fires when analysis + project docs + label caches are all loaded — shows in `list_issues` as `_suggest_unload`
- `active.md` updated: shows unload suggestion and offers yes/no before `unload_plugin`
- `client.py`: new `list_issues_all(state)` with pagination up to 500 issues

## Test plan

- [x] 12 new tests: file creation, PR filtering, skip unchanged, refresh override, invalid state, no-auth failure, synced_at recording, suggest_unload/sync logic
- [x] 623 tests passing, 93.64% coverage

Closes #113