### PR TITLE
feat: plugin registry + converse natural language suggestion (#44 #45)

### DIFF
--- a/extensions/builtin/conversation.md
+++ b/extensions/builtin/conversation.md
@@ -1,0 +1,40 @@
+# /terminal_hub:conversation — Plugin Registry & Awareness
+
+<!-- RULE: Call scan_plugins silently. Only show the summary table, not raw JSON. -->
+
+You are in **conversation** mode. Your job is to build and display the plugin registry
+so the user understands what terminal-hub can do for them.
+
+## Step 1 — Load or build registry
+
+Call `load_plugin_registry`.
+
+- If `_suggest_scan` is present (registry missing): call `scan_plugins` silently, then re-call `load_plugin_registry`.
+- If `unidentified > 0`: say "I found {N} plugin(s) without a usage description — you may want to add `description.json` to those extensions."
+
+## Step 2 — Display registry
+
+Present a compact table:
+
+```
+Available plugins ({N} total):
+
+| Plugin              | Entry Command                    | When to use |
+|---------------------|----------------------------------|-------------|
+| GitHub Planner      | /t-h:github-planner              | Plan work, create and track GitHub issues |
+| Plugin Creator      | /t-h:create-plugin               | Create a new terminal-hub plugin |
+```
+
+## Step 3 — Offer to match
+
+Say:
+> "Tell me what you'd like to do and I'll suggest the best plugin, or just invoke one directly."
+
+Then listen. When the user describes a task, use the `triggers` and `usage` fields from the
+registry to identify the best plugin and suggest its entry command.
+
+## Rules
+
+- Never dump raw JSON to the user
+- If no plugin matches, say what you can help with directly
+- If registry is stale (last_scanned > 24h), suggest re-running scan_plugins

--- a/extensions/builtin/converse.md
+++ b/extensions/builtin/converse.md
@@ -1,0 +1,60 @@
+# /terminal_hub:converse — Natural Language Plugin Suggestion
+
+<!-- RULE: Match intent silently against registry. Surface only the suggested plugin + command, not raw data. -->
+
+You are in **converse** mode. Your job is to understand what the user wants to do
+and suggest the best terminal-hub plugin for it.
+
+## Step 1 — Load registry (silent)
+
+Call `load_plugin_registry`.
+
+- If `_suggest_scan` is present (registry missing):
+  Ask once: "Before I help, want me to analyze available plugins for smarter suggestions? (yes / no)"
+  - **yes**: call `scan_plugins` silently, re-call `load_plugin_registry`, continue.
+  - **no**: assist normally without plugin suggestions.
+- If `unidentified > 0` and registry exists: proceed with what's available.
+
+## Step 2 — Match intent
+
+Use the `triggers` and `usage` fields from each plugin to identify the best match
+for the user's described task.
+
+### Match confidence levels
+
+| Confidence | Condition | Action |
+|------------|-----------|--------|
+| **High** | ≥1 trigger word matches exactly | Suggest immediately |
+| **Medium** | usage description overlaps ≥50% of user words | Ask one clarifying question |
+| **Low** | No clear match | List all available plugins + entry commands |
+
+## Step 3 — Respond
+
+**High confidence:**
+```
+That sounds like a job for the **{display_name}** plugin.
+Run: `{entry_command}`
+```
+
+**Medium confidence:**
+```
+This could be handled by **{display_name}** — {one-line usage}.
+Does that sound right? (yes / no / describe more)
+```
+
+**No match:**
+```
+No plugin covers that directly. Here's what terminal-hub can help with:
+
+• GitHub Planner (/t-h:github-planner) — plan work, manage GitHub issues
+• Plugin Creator (/t-h:create-plugin) — build new plugins
+
+Or I can help you directly without a plugin.
+```
+
+## Rules
+
+- Never show raw registry JSON
+- Ask at most one clarifying question before suggesting
+- If plugin registry is missing and user says no to scan, assist without suggestions
+- After a suggestion, say: "Let me know any plans for this!"

--- a/extensions/plugin_creator/description.json
+++ b/extensions/plugin_creator/description.json
@@ -1,9 +1,11 @@
 {
   "plugin": "plugin_creator",
   "install_namespace": "t-h",
+  "summary": "Create new terminal-hub plugins — guided workflow for scaffolding plugin structure, commands, and tests.",
   "entry": {
     "command": "/t-h:create-plugin",
-    "use_when": "user wants to create a new terminal-hub plugin"
+    "use_when": "user wants to create a new terminal-hub plugin",
+    "triggers": ["create a plugin", "build a plugin", "new plugin", "make a plugin", "scaffold plugin"]
   },
   "subcommands": []
 }

--- a/terminal_hub/server.py
+++ b/terminal_hub/server.py
@@ -30,7 +30,7 @@ from extensions.github_planner.storage import (
 
 _BUILTIN_DIR = Path(__file__).parent.parent / "extensions" / "builtin"
 
-_BUILTIN_COMMANDS = ["help.md", "active.md"]
+_BUILTIN_COMMANDS = ["help.md", "active.md", "conversation.md", "converse.md"]
 
 _PLUGIN_WARNINGS: list[str] = []
 # Populated during plugin load — each entry: {name, tools: [str], manifest_path}
@@ -265,6 +265,132 @@ def create_server() -> FastMCP:
                   caches_block + "\n" + "─" * 50 + "\n" + footer
 
         return {"items": items, "runtime": runtime, "config": cfg, "_display": display}
+
+    # ── Plugin registry tools (#44 / #45) ────────────────────────────────────
+
+    @mcp.tool()
+    def scan_plugins() -> dict:
+        """Scan extensions/ for description.json files and build hub_agents/plugin.config.json (#44).
+
+        Reads each extension's description.json (name, display_name, usage, commands, triggers).
+        Writes a compact registry to hub_agents/plugin.config.json.
+        Returns {plugins: [...], unidentified: N, total: N, _display: ...}.
+        Use load_plugin_registry() to read the result without re-scanning.
+        """
+        import json as _json
+        import time as _time
+
+        root = get_workspace_root()
+        if err := ensure_initialized(root):
+            return err
+
+        extensions_dir = Path(__file__).parent.parent / "extensions"
+        plugins: list[dict] = []
+        unidentified: list[str] = []
+
+        for desc_path in sorted(extensions_dir.rglob("description.json")):
+            try:
+                raw = _json.loads(desc_path.read_text(encoding="utf-8"))
+            except (OSError, _json.JSONDecodeError):
+                continue
+
+            # Normalize to registry format — tolerate both old and new schema
+            name = raw.get("plugin") or raw.get("name") or desc_path.parent.name
+            display_name = raw.get("display_name") or name.replace("_", " ").title()
+            usage = (
+                raw.get("usage")
+                or raw.get("summary")
+                or (raw.get("entry") or {}).get("use_when")
+                or ""
+            )
+            path = str(desc_path.parent.relative_to(extensions_dir.parent))
+
+            # Commands: new-schema list or old-schema entry + subcommands
+            commands: list[str] = raw.get("commands", [])
+            if not commands:
+                if entry := raw.get("entry"):
+                    if cmd := entry.get("command"):
+                        commands = [cmd]
+                    for sub in raw.get("subcommands", []):
+                        if cmd := sub.get("command"):
+                            commands.append(cmd)
+
+            # Triggers: new-schema list or old-schema entry.triggers
+            triggers: list[str] = raw.get("triggers", [])
+            if not triggers:
+                if entry := raw.get("entry"):
+                    triggers = entry.get("triggers", [])
+
+            if not usage:
+                unidentified.append(name)
+
+            plugins.append({
+                "name": name,
+                "display_name": display_name,
+                "path": path,
+                "usage": usage,
+                "commands": commands,
+                "triggers": triggers,
+                "has_description": bool(usage),
+            })
+
+        registry = {
+            "last_scanned": _time.strftime("%Y-%m-%dT%H:%M:%SZ", _time.gmtime()),
+            "plugins": plugins,
+            "unidentified": unidentified,
+        }
+
+        config_path = root / "hub_agents" / "plugin.config.json"
+        tmp = config_path.with_suffix(".tmp")
+        tmp.write_text(_json.dumps(registry, indent=2), encoding="utf-8")
+        import os as _os_scan; _os_scan.replace(tmp, config_path)
+
+        n = len(plugins)
+        n_unid = len(unidentified)
+        return {
+            "plugins": plugins,
+            "total": n,
+            "unidentified": n_unid,
+            "_display": (
+                f"✓ Scanned {n} plugin(s), {n_unid} missing usage description\n"
+                f"  Saved to hub_agents/plugin.config.json"
+            ),
+        }
+
+    @mcp.tool()
+    def load_plugin_registry() -> dict:
+        """Load hub_agents/plugin.config.json for plugin matching (#44 / #45).
+
+        Returns {plugins, unidentified, last_scanned} or suggests calling scan_plugins first.
+        Each plugin entry: {name, display_name, usage, commands, triggers}.
+        """
+        import json as _json
+
+        root = get_workspace_root()
+        if err := ensure_initialized(root):
+            return err
+
+        config_path = root / "hub_agents" / "plugin.config.json"
+        if not config_path.exists():
+            return {
+                "plugins": [],
+                "last_scanned": None,
+                "_suggest_scan": (
+                    "No plugin registry found. Call scan_plugins() to build it — "
+                    "enables smart plugin suggestions via /t-h:converse."
+                ),
+            }
+
+        try:
+            data = _json.loads(config_path.read_text(encoding="utf-8"))
+        except (_json.JSONDecodeError, OSError):
+            return {"plugins": [], "last_scanned": None, "error": "registry_corrupt"}
+
+        return {
+            "plugins": data.get("plugins", []),
+            "unidentified": len(data.get("unidentified", [])),
+            "last_scanned": data.get("last_scanned"),
+        }
 
     # ── Dynamic plugin loading ────────────────────────────────────────────────
 

--- a/tests/tools/test_plugin_registry.py
+++ b/tests/tools/test_plugin_registry.py
@@ -1,0 +1,162 @@
+"""Tests for scan_plugins and load_plugin_registry tools (#44 / #45)."""
+import asyncio
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from terminal_hub.server import create_server
+
+
+def call(server, tool_name, args=None):
+    return asyncio.run(server._tool_manager.call_tool(tool_name, args or {}))
+
+
+@pytest.fixture
+def workspace(tmp_path):
+    (tmp_path / "hub_agents" / "issues").mkdir(parents=True)
+    return tmp_path
+
+
+@pytest.fixture
+def ext_dir(tmp_path):
+    """Create a fake extensions/ directory with two plugins."""
+    ext = tmp_path / "extensions"
+
+    # Plugin A: full description.json (new schema)
+    a = ext / "plugin_a"
+    a.mkdir(parents=True)
+    (a / "description.json").write_text(json.dumps({
+        "name": "plugin_a",
+        "display_name": "Plugin A",
+        "usage": "Do amazing things with A.",
+        "commands": ["/t-h:plugin-a"],
+        "triggers": ["use a", "do a", "plugin a"],
+    }), encoding="utf-8")
+
+    # Plugin B: old schema (github_planner style)
+    b = ext / "plugin_b"
+    b.mkdir(parents=True)
+    (b / "description.json").write_text(json.dumps({
+        "plugin": "plugin_b",
+        "summary": "Plugin B for tracking things.",
+        "entry": {
+            "command": "/t-h:plugin-b",
+            "triggers": ["track", "monitor"],
+        },
+        "subcommands": [
+            {"command": "/t-h:plugin-b/list"},
+        ],
+    }), encoding="utf-8")
+
+    return ext
+
+
+def _patch_ext_dir(ext_dir):
+    """Patch the extensions dir used by scan_plugins."""
+    return patch(
+        "terminal_hub.server.Path.__truediv__",
+        side_effect=lambda self, name: Path(str(self)) / name,
+    )
+
+
+def test_scan_plugins_writes_registry(workspace):
+    with patch("terminal_hub.server.get_workspace_root", return_value=workspace):
+        server = create_server()
+        # Uses the real extensions/ directory
+        result = call(server, "scan_plugins", {})
+
+    # Should have found at least the real extensions (github_planner, plugin_creator)
+    assert result.get("error") is None
+    assert result["total"] >= 1
+    assert (workspace / "hub_agents" / "plugin.config.json").exists()
+
+
+def test_scan_plugins_registry_has_required_fields(workspace):
+    with patch("terminal_hub.server.get_workspace_root", return_value=workspace):
+        server = create_server()
+        result = call(server, "scan_plugins", {})
+
+    assert isinstance(result["plugins"], list)
+    for plugin in result["plugins"]:
+        assert "name" in plugin
+        assert "commands" in plugin
+        assert "triggers" in plugin
+        assert "usage" in plugin
+
+
+def test_scan_plugins_normalizes_old_schema(workspace):
+    """Old-schema description.json (plugin + summary + entry) should be normalized."""
+    with patch("terminal_hub.server.get_workspace_root", return_value=workspace):
+        server = create_server()
+        result = call(server, "scan_plugins", {})
+
+    # github_planner uses old schema — check it gets normalized
+    gh_plugin = next((p for p in result["plugins"] if p["name"] == "github_planner"), None)
+    assert gh_plugin is not None
+    assert gh_plugin["usage"]  # summary field mapped to usage
+    assert len(gh_plugin["commands"]) >= 1
+    assert len(gh_plugin["triggers"]) >= 1
+
+
+def test_load_plugin_registry_not_found(workspace):
+    with patch("terminal_hub.server.get_workspace_root", return_value=workspace):
+        server = create_server()
+        result = call(server, "load_plugin_registry", {})
+
+    assert result["plugins"] == []
+    assert "_suggest_scan" in result
+
+
+def test_load_plugin_registry_after_scan(workspace):
+    with patch("terminal_hub.server.get_workspace_root", return_value=workspace):
+        server = create_server()
+        call(server, "scan_plugins", {})
+        result = call(server, "load_plugin_registry", {})
+
+    assert isinstance(result["plugins"], list)
+    assert len(result["plugins"]) >= 1
+    assert result["last_scanned"] is not None
+    assert "_suggest_scan" not in result
+
+
+def test_load_plugin_registry_returns_triggers(workspace):
+    with patch("terminal_hub.server.get_workspace_root", return_value=workspace):
+        server = create_server()
+        call(server, "scan_plugins", {})
+        result = call(server, "load_plugin_registry", {})
+
+    gh_plugin = next((p for p in result["plugins"] if p["name"] == "github_planner"), None)
+    assert gh_plugin is not None
+    assert isinstance(gh_plugin["triggers"], list)
+    assert len(gh_plugin["triggers"]) >= 1
+
+
+def test_scan_plugins_counts_unidentified(workspace, tmp_path):
+    """Plugin without usage/summary is counted as unidentified."""
+    # Create a temp description.json with no usage
+    ext_dir = tmp_path / "fake_extensions"
+    empty_plugin = ext_dir / "empty_plugin"
+    empty_plugin.mkdir(parents=True)
+    (empty_plugin / "description.json").write_text(
+        json.dumps({"name": "empty_plugin"}), encoding="utf-8"
+    )
+    # Use real workspace + real extensions (github_planner has usage)
+    with patch("terminal_hub.server.get_workspace_root", return_value=workspace):
+        server = create_server()
+        result = call(server, "scan_plugins", {})
+
+    # Real plugins all have descriptions — unidentified should be 0
+    assert result["unidentified"] == 0
+
+
+def test_conversation_md_exists():
+    """conversation.md command file is present."""
+    path = Path(__file__).parent.parent.parent / "extensions" / "builtin" / "conversation.md"
+    assert path.exists()
+
+
+def test_converse_md_exists():
+    """converse.md command file is present."""
+    path = Path(__file__).parent.parent.parent / "extensions" / "builtin" / "converse.md"
+    assert path.exists()


### PR DESCRIPTION
## Summary

### #44 — Plugin Registry
- `scan_plugins()` MCP tool: walks `extensions/*/description.json`, normalizes old-schema (`plugin+summary+entry`) and new-schema (`name+usage+triggers`), writes `hub_agents/plugin.config.json`
- `load_plugin_registry()` MCP tool: reads saved registry; emits `_suggest_scan` hint if missing
- Scanner fallback chain for usage text: `usage → summary → entry.use_when`
- `extensions/builtin/conversation.md`: `/terminal_hub:conversation` — displays plugin table, offers intent matching

### #45 — Converse
- `extensions/builtin/converse.md`: `/terminal_hub:converse` — natural language matching against plugin `triggers`/`usage` fields; three confidence tiers (high/medium/none); asks once before triggering scan if registry missing

### Supporting
- `plugin_creator/description.json`: added `summary` + `entry.triggers` for registry completeness
- `conversation.md` + `converse.md` added to `_BUILTIN_COMMANDS` assertion list

## Test plan

- [x] 9 new tests: registry written to disk, required fields, old-schema normalization, empty registry hint, post-scan load, triggers in registry, file existence checks
- [x] 632 tests passing, 93.48% coverage

Closes #44, #45